### PR TITLE
Add ServicePort 'Name' field so SRV records are made

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ A Kubernetes operator for [Percona Server for MongoDB](https://www.percona.com/s
     percona-server-mongodb-operator-754846f95d-z4vh9   1/1     Running   0          17m
     rs0-0                                              1/1     Running   0          17m
     ``` 
-1. From a *'mongo'* shell add a [readWrite](https://docs.mongodb.com/manual/reference/built-in-roles/#readWrite) user for use with an application *(mongo --host= field may vary for your situation - host must be PRIMARY)*:
+1. From a *'mongo'* shell add a [readWrite](https://docs.mongodb.com/manual/reference/built-in-roles/#readWrite) user for use with an application *(hostname/replicaSet in mongo uri may vary for your situation)*:
     ```
     $ kubectl run -i --rm --tty percona-client --image=percona/percona-server-mongodb:3.6 --restart=Never -- bash -il
-    mongodb@percona-client:/$ mongo -u userAdmin -p admin123456 --host=rs0-0.my-cluster-name admin
+    mongodb@percona-client:/$ mongo mongodb+srv://userAdmin:admin123456@my-cluster-name.psmdb.svc.cluster.local/admin?replicaSet=rs0
     rs0:PRIMARY> db.createUser({
         user: "app",
         pwd: "myAppPassword",
@@ -68,7 +68,7 @@ A Kubernetes operator for [Percona Server for MongoDB](https://www.percona.com/s
 1. Again from a *'mongo'* shell, insert and retrieve a test document in the *'myApp'* database as the new application user:
     ```
     $ kubectl run -i --rm --tty percona-client --image=percona/percona-server-mongodb:3.6 --restart=Never -- bash -il
-    mongodb@percona-client:/$ mongo -u app -p myAppPassword --host=rs0-0.my-cluster-name admin
+    mongodb@percona-client:/$ mongo mongodb+srv://myApp:myAppPassword@my-cluster-name.psmdb.svc.cluster.local/admin?replicaSet=rs0
     rs0:PRIMARY> use myApp
     switched to db myApp
     rs0:PRIMARY> db.test.insert({ x: 1 })

--- a/pkg/stub/psmdb.go
+++ b/pkg/stub/psmdb.go
@@ -214,6 +214,7 @@ func newPSMDBService(m *v1alpha1.PerconaServerMongoDB) *corev1.Service {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
+					Name:       mongodPortName,
 					Port:       m.Spec.Mongod.Port,
 					TargetPort: intstr.FromInt(int(m.Spec.Mongod.Port)),
 				},


### PR DESCRIPTION
Before this change SRV records were not being made for the ServicePort.

After:
```
root@dns-client:/# dig _mongodb._tcp.my-cluster-name.psmdb.svc.cluster.local SRV

; <<>> DiG 9.9.5-9+deb8u16-Debian <<>> _mongodb._tcp.my-cluster-name.psmdb.svc.cluster.local SRV
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44675
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 4

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;_mongodb._tcp.my-cluster-name.psmdb.svc.cluster.local. IN SRV

;; ANSWER SECTION:
_mongodb._tcp.my-cluster-name.psmdb.svc.cluster.local. 5 IN SRV	0 33 27017 rs0-0.my-cluster-name.psmdb.svc.cluster.local.
_mongodb._tcp.my-cluster-name.psmdb.svc.cluster.local. 5 IN SRV	0 33 27017 rs0-1.my-cluster-name.psmdb.svc.cluster.local.
_mongodb._tcp.my-cluster-name.psmdb.svc.cluster.local. 5 IN SRV	0 33 27017 rs0-2.my-cluster-name.psmdb.svc.cluster.local.

;; ADDITIONAL SECTION:
rs0-1.my-cluster-name.psmdb.svc.cluster.local. 5 IN A 172.17.0.7
rs0-0.my-cluster-name.psmdb.svc.cluster.local. 5 IN A 172.17.0.6
rs0-2.my-cluster-name.psmdb.svc.cluster.local. 5 IN A 172.17.0.8

;; Query time: 10 msec
;; SERVER: 10.96.0.10#53(10.96.0.10)
;; WHEN: Tue Oct 30 14:52:55 UTC 2018
;; MSG SIZE  rcvd: 619
```

This allows users to use mongodb+srv:// URIs which will auto-find the Primary, eg:

> mongodb+srv://USER:PASSWORD@my-cluster-name.psmdb.svc.cluster.local/admin?replicaSet=REPLSET

README.md was updated to use mongodb+srv:// instead.