### PR TITLE
Update resource names to include service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ A Kubernetes operator for [Percona Server for MongoDB](https://www.percona.com/s
     ```
     $ kubectl get pods
     NAME                                               READY   STATUS    RESTARTS   AGE
-    percona-server-mongodb-operator-754846f95d-z4vh9   1/1     Running   0          17m
-    rs0-0                                              1/1     Running   0          17m
+    my-cluster-name-rs0-0                              1/1     Running   0          8m
+    my-cluster-name-rs0-1                              1/1     Running   0          8m
+    my-cluster-name-rs0-2                              1/1     Running   0          7m
+    percona-server-mongodb-operator-754846f95d-sf6h6   1/1     Running   0          9m
     ``` 
 1. From a *'mongo'* shell add a [readWrite](https://docs.mongodb.com/manual/reference/built-in-roles/#readWrite) user for use with an application *(mongo --host= field may vary for your situation - host must be PRIMARY)*:
     ```

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   version: "3.6"
   secrets:
-    key: percona-server-mongodb-key
-    users: percona-server-mongodb-users
+    key: my-cluster-name-mongodb-key
+    users: my-cluster-name-mongodb-users
   mongod:
     size: 3
     replsetName: rs0

--- a/deploy/mongodb-users.yaml
+++ b/deploy/mongodb-users.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: percona-server-mongodb-users
+  name: my-cluster-name-mongodb-users
 type: Opaque
 data:
   MONGODB_BACKUP_USER: YmFja3Vw


### PR DESCRIPTION
Before:
```
$ kubectl get pods
NAME                                               READY   STATUS    RESTARTS   AGE
percona-server-mongodb-operator-754846f95d-z4vh9   1/1     Running   0          17m
rs0-0                                              1/1     Running   0          17m
```

After:
```
$ kubectl get pods
NAME                                               READY   STATUS    RESTARTS   AGE
my-cluster-name-rs0-0                              1/1     Running   0          8m
my-cluster-name-rs0-1                              1/1     Running   0          8m
my-cluster-name-rs0-2                              1/1     Running   0          7m
percona-server-mongodb-operator-754846f95d-sf6h6   1/1     Running   0          9m
```