### PR TITLE
Fix stdout/stderr from execCommandInContainer() logging

### DIFF
--- a/pkg/stub/exec.go
+++ b/pkg/stub/exec.go
@@ -20,7 +20,7 @@ func printOutputBuffer(cmd, pod string, r io.Reader, out io.Writer) error {
 	logrus.SetOutput(out)
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		fmt.Fprintf(out, "%s (%s): %s", cmd, pod, scanner.Text())
+		fmt.Fprintf(out, "%s (%s): %s\n", cmd, pod, scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
 		logrus.Errorf("Error printing output from %s (%s): %v", cmd, pod, err)


### PR DESCRIPTION
Add missing "\n" to fmt.Fprint() so we get proper stdout logging, instead of this ugly 1-line blob:
```
time="2018-11-14T14:43:00Z" level=info msg="/mongodb/k8s-mongodb-initiator stdout:"
/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:42:56.908 k8s-mongodb-initiator  initiator.go:219 INFO   Mongod replset initiator started  service=my-cluster-name/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:42:56.908 k8s-mongodb-initiator  initiator.go:223 INFO   Waiting to start initiation  sleep=0s/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:42:56.910 k8s-mongodb-initiator  initiator.go:154 INFO   Connected to MongoDB  auth=false host=localhost:27017 replset= ssl=false ssl_secure=false/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:42:56.911 k8s-mongodb-initiator  initiator.go:72  INFO   Initiating replset /mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): {/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 	"_id": "rs0",/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 	"version": 1,/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 	"members": [/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 		{/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			"_id": 0,/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			"host": "my-cluster-name-rs0-0.my-cluster-name-rs0.psmdb.svc.cluster.local:27017",/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 		"arbiterOnly": false,/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			"buildIndexes": true,/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			"hidden": false,/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			"priority": 1,/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			"tags": {/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			"serviceName": "my-cluster-name"/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			},/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			"slaveDelay": 0,/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 			"votes": 1/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 		}/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 	]/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): }/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:42:56.996 k8s-mongodb-initiator  initiator.go:80  INFO   Initiated replset with config:  version=1/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:42:56.996 k8s-mongodb-initiator  initiator.go:201 INFO   Waiting for host to become primary /mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:42:59.998 k8s-mongodb-initiator  user.go:49       INFO   Adding/updating MongoDB user  db=admin otherDBRoles=map[] roles=[userAdminAnyDatabase] user=userAdmin/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:43:00.118 k8s-mongodb-initiator  initiator.go:242 INFO   Closing localhost connection, reconnecting with a replset+auth connection /mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:43:00.202 k8s-mongodb-initiator  initiator.go:186 INFO   Connected to MongoDB  auth=true host=my-cluster-name-rs0-0.my-cluster-name-rs0.psmdb.svc.cluster.local:27017 replset=rs0 ssl=false ssl_secure=true/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:43:00.203 k8s-mongodb-initiator  user.go:49       INFO   Adding/updating MongoDB user  db=admin otherDBRoles=map[] roles=[clusterAdmin] user=clusterAdmin/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:43:00.299 k8s-mongodb-initiator  user.go:49       INFO   Adding/updating MongoDB user  db=admin otherDBRoles=map[] roles=[clusterMonitor] user=clusterMonitor/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:43:00.395 k8s-mongodb-initiator  user.go:49       INFO   Adding/updating MongoDB user  db=admin otherDBRoles=map[] roles=[backup clusterMonitor restore] user=backup/mongodb/k8s-mongodb-initiator (my-cluster-name-rs0-0): 2018-11-14 14:43:00.422 k8s-mongodb-initiator  initiator.go:258 INFO   Mongod replset initiator complete time="2018-11-14T14:43:00Z" level=info msg="changed state to initialised for replset rs0"```