### PR TITLE
Update rbac.yaml to not use "*" verbs and resources

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -51,8 +51,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: default-account-percona-server-mongodb-operator
 subjects:
-  - kind: ServiceAccount
-    name: default
+- kind: ServiceAccount
+  name: default
 roleRef:
   kind: Role
   name: percona-server-mongodb-operator

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -17,9 +17,7 @@ rules:
   - pods
   - pods/exec
   - services
-  - endpoints
   - persistentvolumeclaims
-  - configmaps
   - secrets
   verbs:
   - "create"
@@ -27,8 +25,6 @@ rules:
   - "delete"
   - "get"
   - "list"
-  - "watch"
-  - "patch"
 - apiGroups:
   - apps
   resources:
@@ -41,8 +37,6 @@ rules:
   - "delete"
   - "get"
   - "list"
-  - "watch"
-  - "patch"
 
 ---
 

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -36,7 +36,6 @@ rules:
   - "update"
   - "delete"
   - "get"
-  - "list"
 
 ---
 

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -6,9 +6,11 @@ rules:
 - apiGroups:
   - psmdb.percona.com
   resources:
-  - "*"
+  - perconaservermongodbs
   verbs:
-  - "*"
+  - "list"
+  - "update"
+  - "watch"
 - apiGroups:
   - ""
   resources:
@@ -17,20 +19,30 @@ rules:
   - services
   - endpoints
   - persistentvolumeclaims
-  - events
   - configmaps
   - secrets
   verbs:
-  - "*"
+  - "create"
+  - "update"
+  - "delete"
+  - "get"
+  - "list"
+  - "watch"
+  - "patch"
 - apiGroups:
   - apps
   resources:
   - deployments
-  - daemonsets
   - replicasets
   - statefulsets
   verbs:
-  - "*"
+  - "create"
+  - "update"
+  - "delete"
+  - "get"
+  - "list"
+  - "watch"
+  - "patch"
 
 ---
 
@@ -39,8 +51,8 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: default-account-percona-server-mongodb-operator
 subjects:
-- kind: ServiceAccount
-  name: default
+  - kind: ServiceAccount
+    name: default
 roleRef:
   kind: Role
   name: percona-server-mongodb-operator

--- a/pkg/stub/exec_test.go
+++ b/pkg/stub/exec_test.go
@@ -15,12 +15,12 @@ func TestPrintCommandOutput(t *testing.T) {
 	_, err := stdout.WriteString("test stdout")
 	assert.NoError(t, err)
 	printCommandOutput("test", t.Name(), &stdout, &stderr, &output)
-	assert.Regexp(t, "test stdout$", output.String())
-	assert.NotRegexp(t, "stderr$", output.String())
+	assert.Regexp(t, "test stdout\n$", output.String())
+	assert.NotRegexp(t, "stderr\n$", output.String())
 	output.Reset()
 
 	_, err = stderr.WriteString("test stderr")
 	assert.NoError(t, err)
 	printCommandOutput("test", t.Name(), &stdout, &stderr, &output)
-	assert.Regexp(t, "test stderr$", output.String())
+	assert.Regexp(t, "test stderr\n$", output.String())
 }


### PR DESCRIPTION
1. Add exact verbs to rbac.yaml
1. Remove unused 'endpoints', 'event', and 'configmaps' resources from core API group
1. Remove unused 'daemonset' resource from apps API group
1. Fix test failure in pkg/stub/exec_test.go due to last PR #31 