### PR TITLE
Remove initContainer, add Dockerfile for mongod node+extra tools we g…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ GIT_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD|grep -oP "\w+$$")
 GIT_REPO=github.com/Percona-Lab/$(NAME)
 UPX_PATH?=$(shell whereis -b upx|awk '{print $$(NF-0)}')
 
+PSMDB_VERSION?=3.6
 VERSION?=$(shell awk '/Version =/{print $$3}' $(CURDIR)/version/version.go | tr -d \")
 IMAGE="perconalab/$(NAME):$(VERSION)"
+MONGOD_IMAGE="perconalab/$(NAME):$(VERSION)-mongod$(PSMDB_VERSION)"
 ifneq ($(GIT_BRANCH), master)
 	IMAGE="perconalab/$(NAME):$(GIT_BRANCH)"
 endif
@@ -35,8 +37,14 @@ build: tmp/_output/bin/$(NAME)
 docker: tmp/_output/bin/$(NAME)
 	IMAGE=$(IMAGE) /bin/bash $(CURDIR)/tmp/build/docker_build.sh
 
+docker-mongod:
+	docker build --build-arg PSMDB_VERSION=$(PSMDB_VERSION) -t $(MONGOD_IMAGE) $(CURDIR)/tmp/psmdb
+
 docker-push:
 	docker push $(IMAGE)
+
+docker-mongod-push:
+	docker push $(MONGOD_IMAGE)
 
 release:
 	mkdir -p $(CURDIR)/tmp/_output

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
+# percona-server-mongodb-operator
+
+[![Build Status](https://travis-ci.org/Percona-Lab/percona-server-mongodb-operator.svg?branch=master)](https://travis-ci.org/Percona-Lab/percona-server-mongodb-operator)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Percona-Lab/percona-server-mongodb-operator)](https://goreportcard.com/report/github.com/Percona-Lab/percona-server-mongodb-operator)
+[![codecov](https://codecov.io/gh/Percona-Lab/percona-server-mongodb-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/Percona-Lab/percona-server-mongodb-operator)
+
+A Kubernetes operator for [Percona Server for MongoDB](https://www.percona.com/software/mongo-database/percona-server-for-mongodb) based on the [Operator SDK](https://github.com/operator-framework/operator-sdk).
+
 <!-- ToC start -->
 # Table of Contents
 
-1. [percona-server-mongodb-operator](#percona-server-mongodb-operator)
 1. [DISCLAIMER](#disclaimer)
 1. [Requirements](#requirements)
 1. [Run the Operator](#run-the-operator)
@@ -10,13 +17,6 @@
       1. [Development Mode](#development-mode)
    1. [MongoDB Internal Authentication Key (optional)](#mongodb-internal-authentication-key-optional)
 <!-- ToC end -->
-# percona-server-mongodb-operator
-
-[![Build Status](https://travis-ci.org/Percona-Lab/percona-server-mongodb-operator.svg?branch=master)](https://travis-ci.org/Percona-Lab/percona-server-mongodb-operator)
-[![Go Report Card](https://goreportcard.com/badge/github.com/Percona-Lab/percona-server-mongodb-operator)](https://goreportcard.com/report/github.com/Percona-Lab/percona-server-mongodb-operator)
-[![codecov](https://codecov.io/gh/Percona-Lab/percona-server-mongodb-operator/branch/master/graph/badge.svg)](https://codecov.io/gh/Percona-Lab/percona-server-mongodb-operator)
-
-A Kubernetes operator for [Percona Server for MongoDB](https://www.percona.com/software/mongo-database/percona-server-for-mongodb) based on the [Operator SDK](https://github.com/operator-framework/operator-sdk).
 
 # DISCLAIMER
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+<!-- ToC start -->
+# Table of Contents
+
+1. [percona-server-mongodb-operator](#percona-server-mongodb-operator)
+1. [DISCLAIMER](#disclaimer)
+1. [Requirements](#requirements)
+1. [Run the Operator](#run-the-operator)
+1. [Required Secrets](#required-secrets)
+   1. [MongoDB System Users](#mongodb-system-users)
+      1. [Development Mode](#development-mode)
+   1. [MongoDB Internal Authentication Key (optional)](#mongodb-internal-authentication-key-optional)
+<!-- ToC end -->
 # percona-server-mongodb-operator
 
 [![Build Status](https://travis-ci.org/Percona-Lab/percona-server-mongodb-operator.svg?branch=master)](https://travis-ci.org/Percona-Lab/percona-server-mongodb-operator)

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -4,6 +4,7 @@ metadata:
   name: my-cluster-name
 spec:
   version: "3.6"
+  imagePullPolicy: Always
   secrets:
     key: my-cluster-name-mongodb-key
     users: my-cluster-name-mongodb-users

--- a/pkg/apis/psmdb/v1alpha1/types.go
+++ b/pkg/apis/psmdb/v1alpha1/types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sversion "k8s.io/apimachinery/pkg/version"
 )
@@ -23,11 +24,12 @@ type PerconaServerMongoDB struct {
 }
 
 type PerconaServerMongoDBSpec struct {
-	Version  string         `json:"version,omitempty"`
-	RunUID   int64          `json:"runUid,omitempty"`
-	Mongod   *MongodSpec    `json:"mongod,omitempty"`
-	Replsets []*ReplsetSpec `json:"replsets,omitempty"`
-	Secrets  *SecretsSpec   `json:"secrets,omitempty"`
+	Version         string            `json:"version,omitempty"`
+	RunUID          int64             `json:"runUid,omitempty"`
+	Mongod          *MongodSpec       `json:"mongod,omitempty"`
+	Replsets        []*ReplsetSpec    `json:"replsets,omitempty"`
+	Secrets         *SecretsSpec      `json:"secrets,omitempty"`
+	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 }
 
 type PerconaServerMongoDBStatus struct {

--- a/pkg/stub/replset.go
+++ b/pkg/stub/replset.go
@@ -87,7 +87,7 @@ func (h *Handler) handleReplsetInit(m *v1alpha1.PerconaServerMongoDB, replset *v
 		logrus.Infof("Initiating replset %s on running pod: %s", replset.Name, pod.Name)
 
 		return execCommandInContainer(pod, mongodContainerName, []string{
-			"/mongodb/k8s-mongodb-initiator",
+			"k8s-mongodb-initiator",
 			"init",
 		})
 	}

--- a/pkg/stub/secrets.go
+++ b/pkg/stub/secrets.go
@@ -12,9 +12,8 @@ import (
 )
 
 const (
-	mongoDBSecretsDirName    = "mongodb-secrets"
 	mongoDBSecretsDir        = "/etc/mongodb-secrets"
-	mongoDbSecretMongoKeyVal = "mongodb-key"
+	mongoDBSecretMongoKeyVal = "mongodb-key"
 )
 
 // generateMongoDBKey generates a 1024 byte-length random key for MongoDB Internal Authentication
@@ -40,7 +39,7 @@ func newPSMDBMongoKeySecret(m *v1alpha1.PerconaServerMongoDB) *corev1.Secret {
 			Namespace: m.Namespace,
 		},
 		StringData: map[string]string{
-			mongoDbSecretMongoKeyVal: generateMongoDBKey(),
+			mongoDBSecretMongoKeyVal: generateMongoDBKey(),
 		},
 	}
 	addOwnerRefToObject(secret, asOwner(m))

--- a/pkg/stub/secrets_test.go
+++ b/pkg/stub/secrets_test.go
@@ -26,7 +26,7 @@ func TestNewPSMDBMongoKeySecret(t *testing.T) {
 	})
 	assert.NotNil(t, secret)
 	assert.Equal(t, t.Name(), secret.Name)
-	assert.Len(t, secret.StringData[mongoDbSecretMongoKeyVal], 1024)
+	assert.Len(t, secret.StringData[mongoDBSecretMongoKeyVal], 1024)
 }
 
 func TestGetPSMDBSecret(t *testing.T) {
@@ -37,20 +37,20 @@ func TestGetPSMDBSecret(t *testing.T) {
 		},
 	}
 
-	// make mock SDK return secret with test mongoDbSecretMongoKeyVal key
+	// make mock SDK return secret with test mongoDBSecretMongoKeyVal key
 	sdk := &mocks.Client{}
 	sdk.On("Get", mock.AnythingOfType("*v1.Secret")).Return(nil).Run(func(args mock.Arguments) {
 		obj := args.Get(0).(*corev1.Secret)
 		obj.Data = map[string][]byte{
-			mongoDbSecretMongoKeyVal: []byte(t.Name()),
+			mongoDBSecretMongoKeyVal: []byte(t.Name()),
 		}
 	})
 
 	// call getPSMDBSecret() to get secret from mock SDK
-	secret, err := getPSMDBSecret(psmdb, sdk, mongoDbSecretMongoKeyVal)
+	secret, err := getPSMDBSecret(psmdb, sdk, mongoDBSecretMongoKeyVal)
 	assert.NoError(t, err)
 
 	// test secret returned from mock SDK
 	assert.Len(t, secret.Data, 1)
-	assert.Equal(t, []byte(t.Name()), secret.Data[mongoDbSecretMongoKeyVal])
+	assert.Equal(t, []byte(t.Name()), secret.Data[mongoDBSecretMongoKeyVal])
 }

--- a/tmp/psmdb/Dockerfile
+++ b/tmp/psmdb/Dockerfile
@@ -1,0 +1,10 @@
+ARG PSMDB_VERSION
+FROM percona/percona-server-mongodb:$PSMDB_VERSION
+
+USER root
+ADD https://github.com/percona/mongodb-orchestration-tools/releases/download/0.4.1/k8s-mongodb-initiator /usr/local/bin
+ADD https://github.com/percona/mongodb-orchestration-tools/releases/download/0.4.1/mongodb-healthcheck /usr/local/bin
+ADD entrypoint.sh /
+RUN chmod +x /usr/local/bin/*-* /entrypoint.sh
+
+USER mongodb

--- a/tmp/psmdb/entrypoint.sh
+++ b/tmp/psmdb/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# if command starts with an option, prepend mongod
+if [ "${1:0:1}" = '-' ]; then
+	set -- mongod "$@"
+fi
+
+# install keyFile to /data/db
+install -m 0400 /etc/mongodb-secrets/mongodb-key /data/db/.mongod.key
+
+exec "$@"


### PR DESCRIPTION
1. Remove initContainer from Pod
1. Add 'make docker-mongod' and 'make docker-mongod-push' steps
1. Add 'imagePullPolicy' flag
1. Add Dockerfile for image of PSMDB node+extra tools we got with wget before

Note: we will ask the PSMDB devs to fix the group-read permission error in MongoDB so that we can remove the need to copy the secret file.

Also, we will eventually move the changes done in the tmp/psmdb/Dockerfile to percona/percona-server-mongodb if possible.