### PR TITLE
CLOUD-20: Support updating Pods on resources, mongodb config+version change

### DIFF
--- a/pkg/apis/psmdb/v1alpha1/types.go
+++ b/pkg/apis/psmdb/v1alpha1/types.go
@@ -68,10 +68,10 @@ type SecretsSpec struct {
 
 type ReplsetSpec struct {
 	*ResourcesSpec `json:"resources,omitempty"`
-	Name           string `json:"name"`
-	Size           int32  `json:"size"`
-	StorageClass   string `json:"storageClass,omitempty"`
-	Configsvr      bool   `json:"configsvr,omitempty"`
+	Name           string      `json:"name"`
+	Size           int32       `json:"size"`
+	StorageClass   string      `json:"storageClass,omitempty"`
+	ClusterRole    ClusterRole `json:"clusterRole,omitempty"`
 }
 
 type ReplsetMemberStatus struct {
@@ -83,7 +83,7 @@ type ReplsetStatus struct {
 	Name        string                 `json:"name,omitempty"`
 	Pods        []string               `json:"pods,omitempty"`
 	Members     []*ReplsetMemberStatus `json:"members,omitempty"`
-	Configsvr   bool                   `json:"configsvr,omitempty"`
+	ClusterRole ClusterRole            `json:"clusterRole,omitempty"`
 	Initialized bool                   `json:"initialized,omitempty"`
 }
 

--- a/pkg/stub/container_test.go
+++ b/pkg/stub/container_test.go
@@ -8,20 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func TestGetContainer(t *testing.T) {
-	pod := corev1.Pod{
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name: t.Name(),
-				},
-			},
-		},
-	}
-	assert.NotNil(t, getContainer(pod, t.Name()))
-	assert.Nil(t, getContainer(pod, "doesnt exist"))
-}
-
 func TestGetMongodPort(t *testing.T) {
 	assert.Equal(t, "27017", getMongodPort(&corev1.Container{
 		Ports: []corev1.ContainerPort{

--- a/pkg/stub/exec.go
+++ b/pkg/stub/exec.go
@@ -61,7 +61,7 @@ func execCommandInContainer(pod corev1.Pod, containerName string, cmd []string) 
 	}
 
 	// find the mongod container
-	container := getContainer(pod, containerName)
+	container := getPodContainer(&pod, containerName)
 	if container == nil {
 		return nil
 	}

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -70,6 +70,9 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 	case *v1alpha1.PerconaServerMongoDB:
 		psmdb := o
 
+		// apply Spec defaults
+		h.addPSMDBSpecDefaults(psmdb)
+
 		// Ignore the delete event since the garbage collector will clean up all secondary resources for the CR
 		// All secondary resources must have the CR set as their OwnerReference for this to be the case
 		if event.Deleted {

--- a/pkg/stub/pod.go
+++ b/pkg/stub/pod.go
@@ -17,8 +17,8 @@ func podList() *corev1.PodList {
 	}
 }
 
-// getContainer returns a container, if it exists
-func getContainer(pod corev1.Pod, containerName string) *corev1.Container {
+// getPodContainer returns a container, if it exists
+func getPodContainer(pod *corev1.Pod, containerName string) *corev1.Container {
 	for _, cont := range pod.Spec.Containers {
 		if cont.Name == containerName {
 			return &cont
@@ -50,7 +50,7 @@ func statusHasPod(status *v1alpha1.ReplsetStatus, podName string) bool {
 // isMongodPod returns a boolean reflecting if a pod
 // is running a mongod container
 func isMongodPod(pod corev1.Pod) bool {
-	container := getContainer(pod, mongodContainerName)
+	container := getPodContainer(&pod, mongodContainerName)
 	return container != nil
 }
 

--- a/pkg/stub/pod_test.go
+++ b/pkg/stub/pod_test.go
@@ -30,3 +30,17 @@ func TestGetPodNames(t *testing.T) {
 	assert.Len(t, podNames, 2)
 	assert.Equal(t, []string{t.Name() + "-0", t.Name() + "-1"}, podNames)
 }
+
+func TestGetPodContainer(t *testing.T) {
+	pod := corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: t.Name(),
+				},
+			},
+		},
+	}
+	assert.NotNil(t, getPodContainer(&pod, t.Name()))
+	assert.Nil(t, getPodContainer(&pod, "doesnt exist"))
+}

--- a/pkg/stub/psmdb.go
+++ b/pkg/stub/psmdb.go
@@ -117,21 +117,8 @@ func (h *Handler) addPSMDBSpecDefaults(m *v1alpha1.PerconaServerMongoDB) {
 }
 
 // newPSMDBStatefulSet returns a PSMDB stateful set
-func (h *Handler) newPSMDBStatefulSet(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.ReplsetSpec, clusterRole *v1alpha1.ClusterRole) (*appsv1.StatefulSet, error) {
+func (h *Handler) newPSMDBStatefulSet(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.ReplsetSpec, resources *corev1.ResourceRequirements) (*appsv1.StatefulSet, error) {
 	h.addPSMDBSpecDefaults(m)
-
-	limits, err := parseSpecResourceRequirements(replset.Limits)
-	if err != nil {
-		return nil, err
-	}
-	requests, err := parseSpecResourceRequirements(replset.Requests)
-	if err != nil {
-		return nil, err
-	}
-	resources := &corev1.ResourceRequirements{
-		Limits:   limits,
-		Requests: requests,
-	}
 
 	ls := labelsForPerconaServerMongoDB(m, replset)
 	set := &appsv1.StatefulSet{
@@ -157,7 +144,7 @@ func (h *Handler) newPSMDBStatefulSet(m *v1alpha1.PerconaServerMongoDB, replset 
 					Affinity:      newPSMDBPodAffinity(ls),
 					RestartPolicy: corev1.RestartPolicyAlways,
 					Containers: []corev1.Container{
-						h.newPSMDBMongodContainer(m, replset, clusterRole, resources),
+						h.newPSMDBMongodContainer(m, replset, resources),
 					},
 					SecurityContext: &corev1.PodSecurityContext{
 						FSGroup: h.getContainerRunUID(m),

--- a/pkg/stub/replset.go
+++ b/pkg/stub/replset.go
@@ -157,7 +157,9 @@ func (h *Handler) handleStatefulSetUpdate(m *v1alpha1.PerconaServerMongoDB, set 
 	}
 
 	// Ensure the stateful set resources are the same as the spec
-	mongodLimits := corev1.ResourceList{}
+	mongodLimits := corev1.ResourceList{
+		corev1.ResourceStorage: mongod.Resources.Limits[corev1.ResourceStorage],
+	}
 	mongodRequests := corev1.ResourceList{}
 	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 		mongodRequest := mongod.Resources.Requests[resourceName]

--- a/pkg/stub/replset.go
+++ b/pkg/stub/replset.go
@@ -14,6 +14,7 @@ import (
 	podk8s "github.com/percona/mongodb-orchestration-tools/pkg/pod/k8s"
 	"github.com/sirupsen/logrus"
 	mgo "gopkg.in/mgo.v2"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
@@ -132,6 +133,76 @@ func (h *Handler) handleReplsetInit(m *v1alpha1.PerconaServerMongoDB, replset *v
 	return ErrNoRunningMongodContainers
 }
 
+func (h *Handler) handleStatefulSetUpdate(m *v1alpha1.PerconaServerMongoDB, set *appsv1.StatefulSet, replset *v1alpha1.ReplsetSpec, resources *corev1.ResourceRequirements) error {
+	var doUpdate bool
+
+	// Ensure the stateful set size is the same as the spec
+	err := h.client.Get(set)
+	if err != nil {
+		return fmt.Errorf("failed to get stateful set for replset %s: %v", replset.Name, err)
+	}
+	if *set.Spec.Replicas != replset.Size {
+		logrus.Infof("setting replicas to %d for replset: %s", replset.Size, replset.Name)
+		set.Spec.Replicas = &replset.Size
+		doUpdate = true
+	}
+
+	// Ensure the PSMDB version is the same as the spec
+	expectedImage := getPSMDBDockerImageName(m)
+	mongod := &set.Spec.Template.Spec.Containers[0]
+	if mongod != nil && mongod.Image != expectedImage {
+		logrus.Infof("updating spec image for replset %s: %s -> %s", replset.Name, mongod.Image, expectedImage)
+		mongod.Image = expectedImage
+		doUpdate = true
+	}
+
+	// Ensure the stateful set resources are the same as the spec
+	mongodLimits := corev1.ResourceList{}
+	mongodRequests := corev1.ResourceList{}
+	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		mongodRequest := mongod.Resources.Requests[resourceName]
+		specRequest := resources.Requests[resourceName]
+		if specRequest.Cmp(mongod.Resources.Requests[resourceName]) != 0 {
+			logrus.Infof("updating %s resource request: %s -> %s", resourceName, mongodRequest.String(), specRequest.String())
+			mongodRequests[resourceName] = specRequest
+			doUpdate = true
+		} else {
+			mongodRequests[resourceName] = mongodRequest
+		}
+
+		mongodLimit := mongod.Resources.Limits[resourceName]
+		specLimit := resources.Limits[resourceName]
+		if specLimit.Cmp(mongodLimit) != 0 && specLimit.Cmp(mongodRequest) >= 0 {
+			logrus.Infof("updating %s resource limit: %s -> %s", resourceName, mongodLimit.String(), specLimit.String())
+			mongodLimits[resourceName] = specLimit
+			doUpdate = true
+		} else {
+			mongodLimits[resourceName] = mongodLimit
+		}
+	}
+	mongod.Resources.Limits = mongodLimits
+	mongod.Resources.Requests = mongodRequests
+
+	// Ensure mongod args are the same as the args from the spec:
+	expectedMongodArgs := newPSMDBMongodContainerArgs(m, replset, resources)
+	if !reflect.DeepEqual(expectedMongodArgs, mongod.Args) {
+		logrus.Infof("updating container mongod args for replset %s: %v -> %v", replset.Name, mongod.Args, expectedMongodArgs)
+		mongod.Args = expectedMongodArgs
+		doUpdate = true
+	}
+
+	// Do update if something changed
+	if doUpdate {
+		logrus.Infof("updating state for replset: %s", replset.Name)
+		err = h.client.Update(set)
+		if err != nil {
+			return fmt.Errorf("failed to update stateful set for replset %s: %v", replset.Name, err)
+		}
+	}
+
+	return nil
+}
+
 // updateStatus updates the PerconaServerMongoDB status
 func (h *Handler) updateStatus(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.ReplsetSpec, usersSecret *corev1.Secret) (*corev1.PodList, error) {
 	var doUpdate bool
@@ -176,7 +247,31 @@ func (h *Handler) updateStatus(m *v1alpha1.PerconaServerMongoDB, replset *v1alph
 
 // ensureReplsetStatefulSet ensures a StatefulSet exists
 func (h *Handler) ensureReplsetStatefulSet(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.ReplsetSpec) error {
-	set, err := h.newPSMDBStatefulSet(m, replset, nil)
+	limits, err := parseSpecResourceRequirements(replset.Limits)
+	if err != nil {
+		return err
+	}
+	requests, err := parseSpecResourceRequirements(replset.Requests)
+	if err != nil {
+		return err
+	}
+	resources := corev1.ResourceRequirements{
+		Limits:   limits,
+		Requests: requests,
+	}
+
+	lf := logrus.Fields{
+		"version": m.Spec.Version,
+		"size":    replset.Size,
+		"cpu":     replset.Limits.Cpu,
+		"memory":  replset.Limits.Memory,
+		"storage": replset.Limits.Storage,
+	}
+	if replset.StorageClass != "" {
+		lf["storageClass"] = replset.StorageClass
+	}
+
+	set, err := h.newPSMDBStatefulSet(m, replset, &resources)
 	if err != nil {
 		return err
 	}
@@ -186,26 +281,13 @@ func (h *Handler) ensureReplsetStatefulSet(m *v1alpha1.PerconaServerMongoDB, rep
 			return err
 		}
 	} else {
-		logrus.WithFields(logrus.Fields{
-			"size":          replset.Size,
-			"limit_cpu":     replset.Limits.Cpu,
-			"limit_memory":  replset.Limits.Memory,
-			"limit_storage": replset.Limits.Storage,
-		}).Infof("created stateful set for replset: %s", replset.Name)
+		logrus.WithFields(lf).Infof("created stateful set for replset: %s", replset.Name)
 	}
 
-	// Ensure the stateful set size is the same as the spec
-	err = h.client.Get(set)
+	// Ensure the spec is up to date
+	err = h.handleStatefulSetUpdate(m, set, replset, &resources)
 	if err != nil {
 		return fmt.Errorf("failed to get stateful set for replset %s: %v", replset.Name, err)
-	}
-	if *set.Spec.Replicas != replset.Size {
-		logrus.Infof("setting replicas to %d for replset: %s", replset.Size, replset.Name)
-		set.Spec.Replicas = &replset.Size
-		err = h.client.Update(set)
-		if err != nil {
-			return fmt.Errorf("failed to update stateful set for replset %s: %v", replset.Name, err)
-		}
 	}
 
 	return nil

--- a/pkg/stub/replset.go
+++ b/pkg/stub/replset.go
@@ -169,9 +169,7 @@ func (h *Handler) handleStatefulSetUpdate(m *v1alpha1.PerconaServerMongoDB, set 
 	}
 
 	// Ensure the stateful set resources are the same as the spec
-	mongodLimits := corev1.ResourceList{
-		corev1.ResourceStorage: mongod.Resources.Limits[corev1.ResourceStorage],
-	}
+	mongodLimits := corev1.ResourceList{}
 	mongodRequests := corev1.ResourceList{}
 	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 		mongodRequest := mongod.Resources.Requests[resourceName]


### PR DESCRIPTION
1. Update Pods if the resources, mongodb config or version changes.
1. Move building of mongod container args to a new func.

MongoDB stays readable and writeable during Pod update on replsets >= 3 nodes. The rollout starts at node 2, then 1, then 0. When the Primary node is updated MongoDB has a normal failover to node 1 or 2.

Tested on:
- OpenShift 3.11