### PR TITLE
 Fix for watchdog failing to start after operator restart

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -3,7 +3,7 @@ kind: PerconaServerMongoDB
 metadata:
   name: my-cluster-name
 spec:
-  #platform: openshift
+  platform: openshift
   version: "3.6"
   imagePullPolicy: Always
   secrets:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -3,8 +3,8 @@ kind: PerconaServerMongoDB
 metadata:
   name: my-cluster-name
 spec:
-  platform: openshift
-  version: "3.6.8"
+  #platform: openshift
+  version: "3.6"
   imagePullPolicy: Always
   secrets:
     key: my-cluster-name-mongodb-key

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -3,7 +3,7 @@ kind: PerconaServerMongoDB
 metadata:
   name: my-cluster-name
 spec:
-  platform: openshift
+  #platform: openshift
   version: "3.6"
   imagePullPolicy: Always
   secrets:

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -3,8 +3,8 @@ kind: PerconaServerMongoDB
 metadata:
   name: my-cluster-name
 spec:
-  #platform: openshift
-  version: "3.6"
+  platform: openshift
+  version: "3.6.8"
   imagePullPolicy: Always
   secrets:
     key: my-cluster-name-mongodb-key

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -77,8 +77,10 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 		// All secondary resources must have the CR set as their OwnerReference for this to be the case
 		if event.Deleted {
 			logrus.Infof("received deleted event for %s", psmdb.Name)
-			close(h.watchdogQuit)
-			h.watchdog = nil
+			if h.watchdog != nil {
+				close(h.watchdogQuit)
+				h.watchdog = nil
+			}
 			return nil
 		}
 

--- a/pkg/stub/replset.go
+++ b/pkg/stub/replset.go
@@ -322,16 +322,16 @@ func (h *Handler) ensureReplset(m *v1alpha1.PerconaServerMongoDB, podList *corev
 		if err != nil {
 			return nil, err
 		}
-
-		// update status after replset init
 		status.Initialized = true
 		err = h.client.Update(m)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update status for replset %s: %v", replset.Name, err)
 		}
 		logrus.Infof("changed state to initialised for replset %s", replset.Name)
+	}
 
-		// ensure the watchdog is started
+	// ensure the watchdog is started if a replset is initialized
+	if isReplsetInitialized(m, replset, status, podList, usersSecret) {
 		err = h.ensureWatchdog(m, usersSecret)
 		if err != nil {
 			return nil, fmt.Errorf("failed to start watchdog: %v", err)


### PR DESCRIPTION
1. Fix panic on 'Deleted' SDK event when watchdog not started _(close() on a nil channel panic)_
1. Fix for starting watchdog after restart of operator on initialized replset.
1. Add test to test start/stop of watchdog.