### PR TITLE
fix wiredTigerIndexPrefixCompression argument error in 3.6.8

### DIFF
--- a/pkg/stub/container.go
+++ b/pkg/stub/container.go
@@ -160,7 +160,7 @@ func newPSMDBMongodContainerArgs(m *v1alpha1.PerconaServerMongoDB, replset *v1al
 				}
 			}
 			if mongod.Storage.WiredTiger.IndexConfig != nil && mongod.Storage.WiredTiger.IndexConfig.PrefixCompression {
-				args = append(args, "--wiredTigerIndexPrefixCompression")
+				args = append(args, "--wiredTigerIndexPrefixCompression=true")
 			}
 		case v1alpha1.StorageEngineInMemory:
 			args = append(args, fmt.Sprintf(


### PR DESCRIPTION
error itself
```
$ mongod --wiredTigerIndexPrefixCompression
Error parsing command line: the required argument for option '--wiredTigerIndexPrefixCompression' is missing
try 'mongod --help' for more information
```