### PR TITLE
CLOUD-42: Add error if no 'resources.limits.storage' is set (required for PVC)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME=percona-server-mongodb-operator
 UID?=$(shell id -u)
-GOCACHE?=off
+GOCACHE?=
 GO_TEST_PATH?=./pkg/stub/...
 GO_TEST_EXTRA?=
 GO_LDFLAGS?=-w -s

--- a/pkg/stub/replset.go
+++ b/pkg/stub/replset.go
@@ -187,7 +187,7 @@ func (h *Handler) ensureReplsetStatefulSet(m *v1alpha1.PerconaServerMongoDB, rep
 	// Check if 'resources.limits.storage' is unset
 	// https://jira.percona.com/browse/CLOUD-42
 	if _, ok := resources.Limits[corev1.ResourceStorage]; !ok {
-		return nil, fmt.Errorf("replset %s does not have required-value 'resources.limits.storage' set!")
+		return nil, fmt.Errorf("replset %s does not have required-value 'resources.limits.storage' set!", replset.Name)
 	}
 
 	lf := logrus.Fields{

--- a/pkg/stub/replset.go
+++ b/pkg/stub/replset.go
@@ -184,6 +184,12 @@ func (h *Handler) ensureReplsetStatefulSet(m *v1alpha1.PerconaServerMongoDB, rep
 		Requests: requests,
 	}
 
+	// Check if 'resources.limits.storage' is unset
+	// https://jira.percona.com/browse/CLOUD-42
+	if _, ok := resources.Limits[corev1.ResourceStorage]; !ok {
+		return nil, fmt.Errorf("replset %s does not have required-value 'resources.limits.storage' set!")
+	}
+
 	lf := logrus.Fields{
 		"version": m.Spec.Version,
 		"size":    replset.Size,

--- a/pkg/stub/replset_test.go
+++ b/pkg/stub/replset_test.go
@@ -4,9 +4,11 @@ import (
 	"testing"
 
 	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/apis/psmdb/v1alpha1"
+	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/sdk/mocks"
 
 	motPkg "github.com/percona/mongodb-orchestration-tools/pkg"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,7 +55,40 @@ func TestGetReplsetDialInfo(t *testing.T) {
 	assert.True(t, di.FailFast)
 }
 
+func TestEnsureReplsetStatefulSet(t *testing.T) {
+	client := &mocks.Client{}
+	h := &Handler{client: client}
+	client.On("Create", mock.AnythingOfType("*v1.StatefulSet")).Return(nil)
+	client.On("Get", mock.AnythingOfType("*v1.StatefulSet")).Return(nil)
+	client.On("Update", mock.AnythingOfType("*v1.StatefulSet")).Return(nil)
+
+	psmdb := &v1alpha1.PerconaServerMongoDB{}
+	replset := &v1alpha1.ReplsetSpec{
+		Name: t.Name(),
+		Size: 3,
+		ResourcesSpec: &v1alpha1.ResourcesSpec{
+			Limits: &v1alpha1.ResourceSpecRequirements{
+				Cpu:     "1m",
+				Memory:  "1m",
+				Storage: "1G",
+			},
+			Requests: &v1alpha1.ResourceSpecRequirements{
+				Cpu:    "1m",
+				Memory: "1m",
+			},
+		},
+	}
+	ss, err := h.ensureReplsetStatefulSet(psmdb, replset)
+	assert.NoError(t, err)
+	assert.NotNil(t, ss)
+
+	// test an error is returned when no storage limit is set
+	// https://jira.percona.com/browse/CLOUD-42
+	replset.ResourcesSpec.Limits.Storage = ""
+	_, err = h.ensureReplsetStatefulSet(psmdb, replset)
+	assert.Error(t, err)
+}
+
 //func TestIsReplsetInitialized(t *testing.T) {}
 //func TestHandlerHandleReplsetInit(t *testing.T) {}
-//func TestEnsureReplsetStatefulSet(t *testing.T) {}
 //func TestHandlerEnsureReplset(t *testing.T) {}


### PR DESCRIPTION
1. Throw an error if there is no 'resource.limits.storage' set.
1. Test that ^^^ error is thrown.