### PR TITLE
Add debug logging to operator

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -712,6 +712,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "770574121bdfdad376605ca2f86ea8fb647b03b83c31a99cddb67fd70e9748d2"
+  inputs-digest = "d95735d2867301a047396e4e09d8c4232276872653f66f7220cf3c97ad997452"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/percona-server-mongodb-operator/main.go
+++ b/cmd/percona-server-mongodb-operator/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"runtime"
 	"time"
 
@@ -14,24 +16,42 @@ import (
 
 	mongodbOT "github.com/percona/mongodb-orchestration-tools"
 
+	"github.com/alecthomas/kingpin"
 	"github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 var (
-	GitCommit string
-	GitBranch string
+	GitCommit   string
+	GitBranch   string
+	verbose     bool
+	versionLine = fmt.Sprintf(
+		"percona/percona-server-mongodb-operator Version: %v, git commit: %s (branch: %s)",
+		version.Version, GitCommit, GitBranch,
+	)
 )
 
 func printVersion() {
 	logrus.Infof("Go Version: %s", runtime.Version())
 	logrus.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
 	logrus.Infof("operator-sdk Version: %v", sdkVersion.Version)
-	logrus.Infof("percona/percona-server-mongodb-operator Version: %v, git commit: %s (branch: %s)", version.Version, GitCommit, GitBranch)
+	logrus.Info(versionLine)
 	logrus.Infof("percona/mongodb-orchestration-tools Version: %v", mongodbOT.Version)
 }
 
 func main() {
+	app := kingpin.New("percona-server-mongodb-operator", "A Kubernetes operator for Percona Server for MongoDB")
+	app.Version(versionLine)
+	app.Flag("verbose", "Enable verbose logging").Envar("LOG_VERBOSE").BoolVar(&verbose)
+	_, err := app.Parse(os.Args[1:])
+	if err != nil {
+		logrus.Fatalf("Cannot parse command line: %v", err)
+	}
+
+	if verbose {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
 	printVersion()
 	opSdk.ExposeMetricsPort()
 

--- a/cmd/percona-server-mongodb-operator/main.go
+++ b/cmd/percona-server-mongodb-operator/main.go
@@ -22,10 +22,11 @@ import (
 )
 
 var (
-	GitCommit   string
-	GitBranch   string
-	verbose     bool
-	versionLine = fmt.Sprintf(
+	GitCommit    string
+	GitBranch    string
+	resyncPeriod time.Duration
+	verbose      bool
+	versionLine  = fmt.Sprintf(
 		"percona/percona-server-mongodb-operator Version: %v, git commit: %s (branch: %s)",
 		version.Version, GitCommit, GitBranch,
 	)
@@ -42,6 +43,7 @@ func printVersion() {
 func main() {
 	app := kingpin.New("percona-server-mongodb-operator", "A Kubernetes operator for Percona Server for MongoDB")
 	app.Version(versionLine)
+	app.Flag("resyncPeriod", "Set the rate of resync from the Kubernetes API").Default("5s").Envar("RESYNC_PERIOD").DurationVar(&resyncPeriod)
 	app.Flag("verbose", "Enable verbose logging").Envar("LOG_VERBOSE").BoolVar(&verbose)
 	_, err := app.Parse(os.Args[1:])
 	if err != nil {
@@ -62,7 +64,6 @@ func main() {
 		logrus.Fatalf("failed to get watch namespace: %v", err)
 	}
 
-	resyncPeriod := time.Duration(5) * time.Second
 	logrus.Infof("Watching %s, %s, %s, %s", resource, kind, namespace, resyncPeriod)
 	opSdk.Watch(resource, kind, namespace, resyncPeriod)
 	opSdk.Handle(stub.NewHandler(sdk.NewClient()))

--- a/cmd/percona-server-mongodb-operator/main.go
+++ b/cmd/percona-server-mongodb-operator/main.go
@@ -45,11 +45,14 @@ func main() {
 	app.Version(versionLine)
 	app.Flag("resyncPeriod", "Set the rate of resync from the Kubernetes API").Default("5s").Envar("RESYNC_PERIOD").DurationVar(&resyncPeriod)
 	app.Flag("verbose", "Enable verbose logging").Envar("LOG_VERBOSE").BoolVar(&verbose)
+
+	// parse flags
 	_, err := app.Parse(os.Args[1:])
 	if err != nil {
 		logrus.Fatalf("Cannot parse command line: %v", err)
 	}
 
+	// optionally enable verbose logging
 	if verbose {
 		logrus.SetLevel(logrus.DebugLevel)
 	}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,4 +31,4 @@ spec:
             - name: RESYNC_PERIOD
               value: 5s
             - name: LOG_VERBOSE
-              value: "true"
+              value: "false"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -28,3 +28,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: percona-server-mongodb-operator
+            - name: RESYNC_PERIOD
+              value: 5s
+            - name: LOG_VERBOSE
+              value: "true"

--- a/internal/sdk/client.go
+++ b/internal/sdk/client.go
@@ -2,8 +2,15 @@ package sdk
 
 import (
 	opSdk "github.com/operator-framework/operator-sdk/pkg/sdk"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+func logFields(object opSdk.Object) logrus.Fields {
+	return logrus.Fields{
+		"kind": object.GetObjectKind(),
+	}
+}
 
 // SDKClient represents the operator-sdk client
 type SDKClient struct{}
@@ -15,30 +22,36 @@ func NewClient() *SDKClient {
 
 // Create wraps the operator-sdk Create function
 func (c *SDKClient) Create(object opSdk.Object) error {
+	logrus.WithFields(logFields(object)).Debugf("sending 'Create' via operator-sdk")
 	return opSdk.Create(object)
 }
 
 // Patch wraps the operator-sdk Patch function
 func (c *SDKClient) Patch(object opSdk.Object, pt types.PatchType, patch []byte) error {
+	logrus.WithFields(logFields(object)).Debugf("sending 'Patch' via operator-sdk")
 	return opSdk.Patch(object, pt, patch)
 }
 
 // Update wraps the operator-sdk Update function
 func (c *SDKClient) Update(object opSdk.Object) error {
+	logrus.WithFields(logFields(object)).Debugf("sending 'Update' via operator-sdk")
 	return opSdk.Update(object)
 }
 
 // Delete wraps the operator-sdk Delete function
 func (c *SDKClient) Delete(object opSdk.Object, opts ...opSdk.DeleteOption) error {
+	logrus.WithFields(logFields(object)).Debugf("sending 'Delete' via operator-sdk")
 	return opSdk.Delete(object, opts...)
 }
 
 // Get wraps the operator-sdk Get function
 func (c *SDKClient) Get(into opSdk.Object, opts ...opSdk.GetOption) error {
+	logrus.WithFields(logFields(into)).Debugf("sending 'Get' via operator-sdk")
 	return opSdk.Get(into, opts...)
 }
 
 // List wraps the operator-sdk List function
 func (c *SDKClient) List(namespace string, into opSdk.Object, opts ...opSdk.ListOption) error {
+	logrus.WithFields(logFields(into)).Debugf("sending 'List' via operator-sdk")
 	return opSdk.List(namespace, into, opts...)
 }


### PR DESCRIPTION
While investigating CLOUD-32 (spec not updating) I needed more verbose logs from the operator. This PR adds the ability to enable verbose operator logging when it is running in Docker/Kubernetes or in development-mode.

Verbose logging is now enabled by setting "LOG_VERBOSE" to "true" in deploy/operator.yaml. Enabling this may help @heartwilltell get a good log of a bug he has noticed. --verbose on the command enables the same in development mode.

1. Added verbose feature.
1. Added debug logs for SDK calls (to help CLOUD-32).