### PR TITLE
CLOUD-44: Resources limits should be optional

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -14,8 +14,8 @@ spec:
     size: 3
     resources:
       limits:
-        cpu: "300m"
-        memory: "0.5G"
+        #cpu: "300m"
+        #memory: "0.5G"
         storage: "1Gi"
       requests:
         cpu: "300m"

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -14,8 +14,8 @@ spec:
     size: 3
     resources:
       limits:
-        #cpu: "300m"
-        #memory: "0.5G"
+        cpu: "300m"
+        memory: "0.5G"
         storage: "1Gi"
       requests:
         cpu: "300m"

--- a/pkg/stub/container.go
+++ b/pkg/stub/container.go
@@ -138,10 +138,12 @@ func newPSMDBMongodContainerArgs(m *v1alpha1.PerconaServerMongoDB, replset *v1al
 	if mongod.Storage != nil {
 		switch mongod.Storage.Engine {
 		case v1alpha1.StorageEngineWiredTiger:
-			args = append(args, fmt.Sprintf(
-				"--wiredTigerCacheSizeGB=%.2f",
-				getWiredTigerCacheSizeGB(resources.Limits, mongod.Storage.WiredTiger.EngineConfig.CacheSizeRatio, true),
-			))
+			if limit, ok := resources.Limits[corev1.ResourceCPU]; ok && !limit.IsZero() {
+				args = append(args, fmt.Sprintf(
+					"--wiredTigerCacheSizeGB=%.2f",
+					getWiredTigerCacheSizeGB(resources.Limits, mongod.Storage.WiredTiger.EngineConfig.CacheSizeRatio, true),
+				))
+			}
 			if mongod.Storage.WiredTiger.CollectionConfig != nil {
 				if mongod.Storage.WiredTiger.CollectionConfig.BlockCompressor != nil {
 					args = append(args,

--- a/pkg/stub/psmdb_test.go
+++ b/pkg/stub/psmdb_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/apis/psmdb/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -99,14 +98,8 @@ func TestNewPSMDBStatefulSet(t *testing.T) {
 	replset := psmdb.Spec.Replsets[0]
 
 	// parse resources
-	limits, err := parseSpecResourceRequirements(replset.Limits)
+	resources, err := parseReplsetResourceRequirements(replset)
 	assert.NoError(t, err)
-	requests, err := parseSpecResourceRequirements(replset.Requests)
-	assert.NoError(t, err)
-	resources := corev1.ResourceRequirements{
-		Limits:   limits,
-		Requests: requests,
-	}
 
 	h := &Handler{
 		serverVersion: &v1alpha1.ServerVersion{

--- a/pkg/stub/replset.go
+++ b/pkg/stub/replset.go
@@ -171,17 +171,9 @@ func (h *Handler) handleStatefulSetUpdate(m *v1alpha1.PerconaServerMongoDB, set 
 
 // ensureReplsetStatefulSet ensures a StatefulSet exists
 func (h *Handler) ensureReplsetStatefulSet(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.ReplsetSpec) (*appsv1.StatefulSet, error) {
-	limits, err := parseSpecResourceRequirements(replset.Limits)
+	resources, err := parseReplsetResourceRequirements(replset)
 	if err != nil {
 		return nil, err
-	}
-	requests, err := parseSpecResourceRequirements(replset.Requests)
-	if err != nil {
-		return nil, err
-	}
-	resources := corev1.ResourceRequirements{
-		Limits:   limits,
-		Requests: requests,
 	}
 
 	// Check if 'resources.limits.storage' is unset

--- a/pkg/stub/util_test.go
+++ b/pkg/stub/util_test.go
@@ -98,6 +98,6 @@ func TestParseReplsetResourceRequirements(t *testing.T) {
 	assert.NotNil(t, r)
 	cpuLimits = r.Limits[corev1.ResourceCPU]
 	cpuRequests = r.Requests[corev1.ResourceCPU]
-	assert.Equal(t, "0", cpuLimits.String())
-	assert.Equal(t, "0", cpuRequests.String())
+	assert.True(t, cpuLimits.IsZero())
+	assert.True(t, cpuRequests.IsZero())
 }


### PR DESCRIPTION
1. Don't set cpu or memory 'requests' if there are no 'limits'.
    1. Don't set wiredTigerCacheSizeGB if we don't know the memory 'limit' _(defaults cache size to 50% of the Kubelet system memory  - so no 'limits' is not-really recommended)_
1. Add unit tests.