### PR TITLE
fix/cleanup

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -22,6 +22,7 @@ var ReplsetInitWait = 10 * time.Second
 
 const minPersistentVolumeClaims = 1
 
+// NewHandler return new instance of sdk.Handler interface.
 func NewHandler(client sdk.Client) opSdk.Handler {
 	return &Handler{
 		client:       client,
@@ -30,6 +31,7 @@ func NewHandler(client sdk.Client) opSdk.Handler {
 	}
 }
 
+// Handler implements sdk.Handler interface.
 type Handler struct {
 	client        sdk.Client
 	serverVersion *v1alpha1.ServerVersion
@@ -117,14 +119,14 @@ func (h *Handler) Handle(ctx context.Context, event opSdk.Event) error {
 		// loop will create the cluster shards and config server replset
 		for _, replset := range psmdb.Spec.Replsets {
 			// Update the PSMDB status
-			podList, err := h.updateStatus(psmdb, replset, usersSecret)
+			podsList, err := h.updateStatus(psmdb, replset, usersSecret)
 			if err != nil {
 				logrus.Errorf("failed to update psmdb status for replset %s: %v", replset.Name, err)
 				return err
 			}
 
 			// Ensure replset exists and has correct state, PVCs, etc
-			err = h.ensureReplset(psmdb, podList, replset, usersSecret)
+			err = h.ensureReplset(psmdb, podsList, replset, usersSecret)
 			if err != nil {
 				if err == ErrNoRunningMongodContainers {
 					logrus.Debugf("no running mongod containers for replset %s, skipping replset initiation", replset.Name)

--- a/pkg/stub/psmdb.go
+++ b/pkg/stub/psmdb.go
@@ -10,23 +10,23 @@ import (
 )
 
 var (
-	defaultVersion                  string  = "latest"
-	defaultRunUID                   int64   = 1001
-	defaultKeySecretName            string  = "percona-server-mongodb-key"
-	defaultUsersSecretName          string  = "percona-server-mongodb-users"
-	defaultMongodSize               int32   = 3
-	defaultReplsetName              string  = "rs"
-	defaultStorageEngine                    = v1alpha1.StorageEngineWiredTiger
-	defaultMongodPort               int32   = 27017
-	defaultWiredTigerCacheSizeRatio float64 = 0.5
-	defaultInMemorySizeRatio        float64 = 0.9
-	defaultOperationProfilingMode           = v1alpha1.OperationProfilingModeSlowOp
-	defaultImagePullPolicy                  = corev1.PullIfNotPresent
-	mongodContainerDataDir          string  = "/data/db"
-	mongodContainerName             string  = "mongod"
-	mongodDataVolClaimName          string  = "mongod-data"
-	mongodPortName                  string  = "mongodb"
-	secretFileMode                  int32   = 0060
+	defaultVersion                        = "latest"
+	defaultRunUID                   int64 = 1001
+	defaultKeySecretName                  = "percona-server-mongodb-key"
+	defaultUsersSecretName                = "percona-server-mongodb-users"
+	defaultMongodSize               int32 = 3
+	defaultReplsetName                    = "rs"
+	defaultStorageEngine                  = v1alpha1.StorageEngineWiredTiger
+	defaultMongodPort               int32 = 27017
+	defaultWiredTigerCacheSizeRatio       = 0.5
+	defaultInMemorySizeRatio              = 0.9
+	defaultOperationProfilingMode         = v1alpha1.OperationProfilingModeSlowOp
+	defaultImagePullPolicy                = corev1.PullIfNotPresent
+	mongodContainerDataDir                = "/data/db"
+	mongodContainerName                   = "mongod"
+	mongodDataVolClaimName                = "mongod-data"
+	mongodPortName                        = "mongodb"
+	secretFileMode                  int32 = 0060
 )
 
 // addPSMDBSpecDefaults sets default values for unset config params

--- a/pkg/stub/status.go
+++ b/pkg/stub/status.go
@@ -62,14 +62,14 @@ func getReplsetMemberStatuses(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha
 func (h *Handler) updateStatus(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.ReplsetSpec, usersSecret *corev1.Secret) (*corev1.PodList, error) {
 	var doUpdate bool
 
-	podList := podList()
-	err := h.client.List(m.Namespace, podList, sdk.WithListOptions(getLabelSelectorListOpts(m, replset)))
+	podsList := podList()
+	err := h.client.List(m.Namespace, podsList, sdk.WithListOptions(getLabelSelectorListOpts(m, replset)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods for replset %s: %v", replset.Name, err)
 	}
 
 	// Update status pods list
-	podNames := getPodNames(podList.Items)
+	podNames := getPodNames(podsList.Items)
 	status := getReplsetStatus(m, replset)
 	if !reflect.DeepEqual(podNames, status.Pods) {
 		status.Pods = podNames
@@ -77,7 +77,7 @@ func (h *Handler) updateStatus(m *v1alpha1.PerconaServerMongoDB, replset *v1alph
 	}
 
 	// Update mongodb replset member status list
-	members := getReplsetMemberStatuses(m, replset, podList.Items, usersSecret)
+	members := getReplsetMemberStatuses(m, replset, podsList.Items, usersSecret)
 	if !reflect.DeepEqual(members, status.Members) {
 		status.Members = members
 		doUpdate = true
@@ -95,7 +95,7 @@ func (h *Handler) updateStatus(m *v1alpha1.PerconaServerMongoDB, replset *v1alph
 	if h.pods == nil {
 		h.pods = podk8s.NewPods(m.Name, m.Namespace)
 	}
-	h.pods.SetPods(podList.Items)
+	h.pods.SetPods(podsList.Items)
 
-	return podList, nil
+	return podsList, nil
 }

--- a/pkg/stub/status.go
+++ b/pkg/stub/status.go
@@ -39,7 +39,6 @@ func getReplsetMemberStatuses(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha
 			logrus.Debugf("Cannot connect to mongodb host %s: %v", dialInfo.Addrs[0], err)
 			continue
 		}
-		defer session.Close()
 		session.SetMode(mgo.Eventual, true)
 
 		logrus.Debugf("Updating status for host: %s", dialInfo.Addrs[0])
@@ -54,6 +53,7 @@ func getReplsetMemberStatuses(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha
 			Name:    dialInfo.Addrs[0],
 			Version: buildInfo.Version,
 		})
+		session.Close()
 	}
 	return members
 }

--- a/pkg/stub/status.go
+++ b/pkg/stub/status.go
@@ -30,7 +30,7 @@ func getReplsetStatus(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.Replse
 
 // getReplsetMemberStatuses returns a list of ReplsetMemberStatus structs for a given replset
 func getReplsetMemberStatuses(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.ReplsetSpec, pods []corev1.Pod, usersSecret *corev1.Secret) []*v1alpha1.ReplsetMemberStatus {
-	members := []*v1alpha1.ReplsetMemberStatus{}
+	members := make([]*v1alpha1.ReplsetMemberStatus, 0)
 	for _, pod := range pods {
 		dialInfo := getReplsetDialInfo(m, replset, []corev1.Pod{pod}, usersSecret)
 		dialInfo.Direct = true


### PR DESCRIPTION
Defer in for loop leeds to resources leek.
Should avoid empty slice declaration via literal.
Rename podList to podsList to avoid shadowing.
Remove redundant type declaration.
