### PR TITLE
Update master to use 'master' version, update Makefile for release branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ UPX_PATH?=$(shell whereis -b upx|awk '{print $$(NF-0)}')
 
 VERSION?=$(shell awk '/Version =/{print $$3}' $(CURDIR)/version/version.go | tr -d \")
 IMAGE="percona/$(NAME):$(VERSION)"
-ifneq ($(GIT_BRANCH), master)
+ifneq ($(GIT_BRANCH), "release-$(VERSION)")
 	IMAGE="percona/$(NAME):$(GIT_BRANCH)"
 endif
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: percona-server-mongodb-operator
-          image: percona/percona-server-mongodb-operator:0.0.1
+          image: percona/percona-server-mongodb-operator:master
           ports:
           - containerPort: 60000
             name: metrics

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the version of the percona-server-mongodb-operator
-var Version = "0.1.0"
+var Version = "master"


### PR DESCRIPTION
This will work better if we plan to build a 'release-X.Y.Z' branch for every release. If you pull 'master' you will use the 'master' Dockertag+version after this PR which is easy to spot in issues.

1. Update master to use 'master' version
1. Update Makefile for release-X.Y.Z branches