### PR TITLE
Do not allow multiple replica sets (yet)

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -117,7 +117,14 @@ func (h *Handler) Handle(ctx context.Context, event opSdk.Event) error {
 
 		// Ensure all replica sets exist. When sharding is supported this
 		// loop will create the cluster shards and config server replset
-		for _, replset := range psmdb.Spec.Replsets {
+		for i, replset := range psmdb.Spec.Replsets {
+			// multiple replica sets is not supported until sharding is
+			// added to the operator
+			if i > 0 {
+				logrus.Errorf("multiple replica sets is not yet supported, skipping replset: %s", replset.Name)
+				continue
+			}
+
 			// Update the PSMDB status
 			podsList, err := h.updateStatus(psmdb, replset, usersSecret)
 			if err != nil {


### PR DESCRIPTION
The 'replsets' section of the spec has an array of replica sets for forward-compatibility but many replica sets is not yet tested/supported.

This PR will log and skip replica sets when the slice-index is greater than 0.