### PR TITLE
CLOUD-51 and CLOUD-52: Allow cpu+mem limits + requests to be commented-out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME=percona-server-mongodb-operator
 UID?=$(shell id -u)
 GOCACHE?=
-GO_TEST_PATH?=./pkg/stub/...
+GO_TEST_PATH?=./...
 GO_TEST_EXTRA?=
 GO_LDFLAGS?=-w -s
 GIT_COMMIT?=$(shell git rev-parse HEAD)

--- a/internal/util/container.go
+++ b/internal/util/container.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetContainerResourceRequirements returns a corev1.ResourceRequirements with the
+// 'storage' type (not needed in corev1.Container) removed
+func GetContainerResourceRequirements(reqs corev1.ResourceRequirements) corev1.ResourceRequirements {
+	var containerReqs corev1.ResourceRequirements
+	reqs.DeepCopyInto(&containerReqs)
+	delete(containerReqs.Limits, corev1.ResourceStorage)
+	return containerReqs
+}

--- a/internal/util/resources.go
+++ b/internal/util/resources.go
@@ -1,0 +1,79 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/apis/psmdb/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// parseResourceRequirementsList parses resource requirements to a corev1.ResourceList
+func parseResourceRequirementsList(rsr *v1alpha1.ResourceSpecRequirements) (corev1.ResourceList, error) {
+	rl := corev1.ResourceList{}
+
+	if rsr.Cpu != "" {
+		cpu := rsr.Cpu
+		if !strings.HasSuffix(cpu, "m") {
+			cpuFloat64, err := strconv.ParseFloat(cpu, 64)
+			if err != nil {
+				return nil, err
+			}
+			cpu = fmt.Sprintf("%.1f", cpuFloat64)
+		}
+		cpuQuantity, err := resource.ParseQuantity(cpu)
+		if err != nil {
+			return nil, err
+		}
+		rl[corev1.ResourceCPU] = cpuQuantity
+	}
+
+	if rsr.Memory != "" {
+		memoryQuantity, err := resource.ParseQuantity(rsr.Memory)
+		if err != nil {
+			return nil, err
+		}
+		rl[corev1.ResourceMemory] = memoryQuantity
+	}
+
+	if rsr.Storage != "" {
+		storageQuantity, err := resource.ParseQuantity(rsr.Storage)
+		if err != nil {
+			return nil, err
+		}
+		rl[corev1.ResourceStorage] = storageQuantity
+	}
+
+	return rl, nil
+}
+
+// ParseResourceSpecRequirements parses the resource section of the spec to a
+// corev1.ResourceRequirements object
+func ParseResourceSpecRequirements(specLimits, specRequests *v1alpha1.ResourceSpecRequirements) (corev1.ResourceRequirements, error) {
+	var rr corev1.ResourceRequirements
+
+	if specLimits != nil {
+		limits, err := parseResourceRequirementsList(specLimits)
+		if err != nil {
+			return rr, err
+		}
+		if len(limits) > 0 {
+			rr.Limits = limits
+		}
+	}
+
+	if specRequests != nil {
+		requests, err := parseResourceRequirementsList(specRequests)
+		if err != nil {
+			return rr, err
+		}
+		if len(requests) > 0 {
+			rr.Requests = requests
+		}
+	}
+
+	return rr, nil
+}

--- a/internal/util/resources_test.go
+++ b/internal/util/resources_test.go
@@ -1,4 +1,4 @@
-package stub
+package util
 
 import (
 	"testing"
@@ -19,6 +19,7 @@ func TestParseResourceRequirementsList(t *testing.T) {
 	assert.NoError(t, err)
 	cpu := parsed[corev1.ResourceCPU]
 	assert.Equal(t, "500m", cpu.String())
+	assert.Len(t, parsed, 3)
 
 	// test float cpu format
 	parsed, err = parseResourceRequirementsList(&v1alpha1.ResourceSpecRequirements{
@@ -65,7 +66,7 @@ func TestParseResourceRequirementsList(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestParseReplsetResourceRequirements(t *testing.T) {
+func TestParseResourceSpecRequirements(t *testing.T) {
 	replset := &v1alpha1.ReplsetSpec{
 		ResourcesSpec: &v1alpha1.ResourcesSpec{
 			Limits: &v1alpha1.ResourceSpecRequirements{
@@ -79,7 +80,7 @@ func TestParseReplsetResourceRequirements(t *testing.T) {
 			},
 		},
 	}
-	r, err := parseReplsetResourceRequirements(replset)
+	r, err := ParseResourceSpecRequirements(replset.Limits, replset.Requests)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.Len(t, r.Limits, 3)
@@ -93,11 +94,31 @@ func TestParseReplsetResourceRequirements(t *testing.T) {
 	assert.Equal(t, "500m", cpuRequests.String())
 
 	replset.ResourcesSpec.Limits.Cpu = ""
-	r, err = parseReplsetResourceRequirements(replset)
+	r, err = ParseResourceSpecRequirements(replset.Limits, replset.Requests)
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 	cpuLimits = r.Limits[corev1.ResourceCPU]
 	cpuRequests = r.Requests[corev1.ResourceCPU]
 	assert.True(t, cpuLimits.IsZero())
-	assert.True(t, cpuRequests.IsZero())
+
+	// test list is empty if empty requirements are sent
+	// https://jira.percona.com/browse/CLOUD-51 and
+	// https://jira.percona.com/browse/CLOUD-52
+	r, err = ParseResourceSpecRequirements(&v1alpha1.ResourceSpecRequirements{}, &v1alpha1.ResourceSpecRequirements{})
+	assert.NoError(t, err)
+	assert.Len(t, r.Limits, 0)
+	assert.Len(t, r.Requests, 0)
+	r, err = ParseResourceSpecRequirements(&v1alpha1.ResourceSpecRequirements{}, &v1alpha1.ResourceSpecRequirements{
+		Cpu:    "500m",
+		Memory: "0.5Gi",
+	})
+	assert.NoError(t, err)
+	assert.Len(t, r.Limits, 0)
+	assert.Len(t, r.Requests, 2)
+
+	// test nil limits+requests
+	r, err = ParseResourceSpecRequirements(nil, nil)
+	assert.NoError(t, err)
+	assert.Len(t, r.Limits, 0)
+	assert.Len(t, r.Requests, 0)
 }

--- a/pkg/stub/container.go
+++ b/pkg/stub/container.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strconv"
 
+	"github.com/Percona-Lab/percona-server-mongodb-operator/internal/util"
 	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/apis/psmdb/v1alpha1"
 	"github.com/Percona-Lab/percona-server-mongodb-operator/version"
 
@@ -298,16 +299,7 @@ func (h *Handler) newPSMDBMongodContainer(m *v1alpha1.PerconaServerMongoDB, repl
 			PeriodSeconds:       int32(3),
 			FailureThreshold:    int32(8),
 		},
-		Resources: corev1.ResourceRequirements{
-			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resources.Limits[corev1.ResourceCPU],
-				corev1.ResourceMemory: resources.Limits[corev1.ResourceMemory],
-			},
-			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resources.Requests[corev1.ResourceCPU],
-				corev1.ResourceMemory: resources.Requests[corev1.ResourceMemory],
-			},
-		},
+		Resources: util.GetContainerResourceRequirements(*resources),
 		SecurityContext: &corev1.SecurityContext{
 			RunAsNonRoot: &trueVar,
 			RunAsUser:    h.getContainerRunUID(m),

--- a/pkg/stub/psmdb_test.go
+++ b/pkg/stub/psmdb_test.go
@@ -3,6 +3,7 @@ package stub
 import (
 	"testing"
 
+	"github.com/Percona-Lab/percona-server-mongodb-operator/internal/util"
 	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/apis/psmdb/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
@@ -98,7 +99,7 @@ func TestNewPSMDBStatefulSet(t *testing.T) {
 	replset := psmdb.Spec.Replsets[0]
 
 	// parse resources
-	resources, err := parseReplsetResourceRequirements(replset)
+	resources, err := util.ParseResourceSpecRequirements(replset.Limits, replset.Requests)
 	assert.NoError(t, err)
 
 	h := &Handler{

--- a/pkg/stub/replset.go
+++ b/pkg/stub/replset.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/Percona-Lab/percona-server-mongodb-operator/internal/util"
 	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/apis/psmdb/v1alpha1"
 
 	motPkg "github.com/percona/mongodb-orchestration-tools/pkg"
@@ -167,7 +168,7 @@ func (h *Handler) handleStatefulSetUpdate(m *v1alpha1.PerconaServerMongoDB, set 
 
 // ensureReplsetStatefulSet ensures a StatefulSet exists
 func (h *Handler) ensureReplsetStatefulSet(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.ReplsetSpec) (*appsv1.StatefulSet, error) {
-	resources, err := parseReplsetResourceRequirements(replset)
+	resources, err := util.ParseResourceSpecRequirements(replset.Limits, replset.Requests)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stub/util.go
+++ b/pkg/stub/util.go
@@ -2,16 +2,11 @@ package stub
 
 import (
 	"encoding/json"
-	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/apis/psmdb/v1alpha1"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sclient"
-	corev1 "k8s.io/api/core/v1"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -63,75 +58,6 @@ func asOwner(m *v1alpha1.PerconaServerMongoDB) metav1.OwnerReference {
 		UID:        m.UID,
 		Controller: &trueVar,
 	}
-}
-
-// parseResourceRequirementsList parses resource requirements to a corev1.ResourceList
-func parseResourceRequirementsList(rsr *v1alpha1.ResourceSpecRequirements) (corev1.ResourceList, error) {
-	rl := corev1.ResourceList{}
-
-	if rsr.Cpu != "" {
-		cpu := rsr.Cpu
-		if !strings.HasSuffix(cpu, "m") {
-			cpuFloat64, err := strconv.ParseFloat(cpu, 64)
-			if err != nil {
-				return nil, err
-			}
-			cpu = fmt.Sprintf("%.1f", cpuFloat64)
-		}
-		cpuQuantity, err := resource.ParseQuantity(cpu)
-		if err != nil {
-			return nil, err
-		}
-		rl[corev1.ResourceCPU] = cpuQuantity
-	}
-
-	if rsr.Memory != "" {
-		memoryQuantity, err := resource.ParseQuantity(rsr.Memory)
-		if err != nil {
-			return nil, err
-		}
-		rl[corev1.ResourceMemory] = memoryQuantity
-	}
-
-	if rsr.Storage != "" {
-		storageQuantity, err := resource.ParseQuantity(rsr.Storage)
-		if err != nil {
-			return nil, err
-		}
-		rl[corev1.ResourceStorage] = storageQuantity
-	}
-
-	return rl, nil
-}
-
-// parseReplsetResourceRequirements parses the resource section of the spec to a
-// corev1.ResourceRequirements object
-func parseReplsetResourceRequirements(replset *v1alpha1.ReplsetSpec) (corev1.ResourceRequirements, error) {
-	var err error
-	rr := corev1.ResourceRequirements{
-		Limits:   corev1.ResourceList{},
-		Requests: corev1.ResourceList{},
-	}
-
-	rr.Limits, err = parseResourceRequirementsList(replset.Limits)
-	if err != nil {
-		return rr, err
-	}
-
-	// only set cpu+memory resource requests if limits are set
-	// https://jira.percona.com/browse/CLOUD-44
-	requests, err := parseResourceRequirementsList(replset.Requests)
-	if err != nil {
-		return rr, err
-	}
-	if _, ok := rr.Limits[corev1.ResourceCPU]; ok {
-		rr.Requests[corev1.ResourceCPU] = requests[corev1.ResourceCPU]
-	}
-	if _, ok := rr.Limits[corev1.ResourceMemory]; ok {
-		rr.Requests[corev1.ResourceMemory] = requests[corev1.ResourceMemory]
-	}
-
-	return rr, nil
 }
 
 // getServerVersion returns server version and platform (k8s|oc)


### PR DESCRIPTION
This is fixes for the '0' CPU and/or Memory resource limits/requests when they are commented out.

1. Make func for parsing container resources. This was done in internal/util because the same resource logic needs to be shared with the upcoming backup code.
1. Improve unit tests to check for this issue.