### PR TITLE
Make Travis-CI check operator-sdk can generate deep copy code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ go:
 matrix:
   allow_failures:
     - go: master
+before_script:
+  - curl -sLo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.0.7/operator-sdk-v0.0.7-x86_64-linux-gnu
+  - chmod +x operator-sdk
 script:
+  - ./operator-sdk generate k8s
   - make test-cover
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This is check for an issue @heartwilltell noticed when running operator-sdk on the API files for every build.

Travis-CI logs:
```
4.21s$ curl -sLo operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/v0.0.7/operator-sdk-v0.0.7-x86_64-linux-gnu
0.00s$ chmod +x operator-sdk
7.32s$ ./operator-sdk generate k8s
Run code-generation for custom resources
Generating deepcopy funcs
```