### PR TITLE
Fix backup agent port-number typo from PR #93, update for cli var renames

### DIFF
--- a/pkg/stub/backup/agent.go
+++ b/pkg/stub/backup/agent.go
@@ -18,11 +18,7 @@ func (c *Controller) newAgentContainerArgs() []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  "PBM_AGENT_SERVER_ADDRESS",
-			Value: c.coordinatorAddress() + ":" + strconv.Itoa(int(coordinatorAPIPort)),
-		},
-		{
-			Name:  "PBM_AGENT_MONGODB_HOST",
-			Value: "127.0.0.1",
+			Value: c.coordinatorAddress() + ":" + strconv.Itoa(int(coordinatorRPCPort)),
 		},
 		{
 			Name:  "PBM_AGENT_MONGODB_PORT",
@@ -33,7 +29,7 @@ func (c *Controller) newAgentContainerArgs() []corev1.EnvVar {
 			Value: "15",
 		},
 		{
-			Name: "PBM_AGENT_MONGODB_USER",
+			Name: "PBM_AGENT_MONGODB_USERNAME",
 			ValueFrom: util.EnvVarSourceFromSecret(
 				c.psmdb.Spec.Secrets.Users,
 				motPkg.EnvMongoDBBackupUser,


### PR DESCRIPTION
1. Fix typo in 'API' vs 'RPC' port number for agent coordinator address. The agent needs to connect to the RPC port, not API port
1. Fix for rename of env var 'PBM_AGENT_MONGODB_USER' -> 'PBM_AGENT_MONGODB_USERNAME'. This was renamed in the backup tool.
1. Remove 'PBM_AGENT_MONGODB_HOST' == '127.0.0.1' env var now that the backup agent defaults to '127.0.0.1'