### PR TITLE
CLOUD-73: Unregister watchdog metrics

### DIFF
--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -29,21 +29,23 @@ const minPersistentVolumeClaims = 1
 
 // Handler implements sdk.Handler interface.
 type Handler struct {
-	client        sdk.Client
-	serverVersion *v1alpha1.ServerVersion
-	pods          *podk8s.Pods
-	watchdog      *watchdog.Watchdog
-	watchdogQuit  chan bool
-	startedAt     time.Time
-	backups       *backup.Controller
+	client          sdk.Client
+	serverVersion   *v1alpha1.ServerVersion
+	pods            *podk8s.Pods
+	watchdog        *watchdog.Watchdog
+	watchdogMetrics *wdMetrics.Collector
+	watchdogQuit    chan bool
+	startedAt       time.Time
+	backups         *backup.Controller
 }
 
 // NewHandler return new instance of sdk.Handler interface.
 func NewHandler(client sdk.Client) opSdk.Handler {
 	return &Handler{
-		client:       client,
-		startedAt:    time.Now(),
-		watchdogQuit: make(chan bool, 1),
+		client:          client,
+		startedAt:       time.Now(),
+		watchdogMetrics: wdMetrics.NewCollector(),
+		watchdogQuit:    make(chan bool, 1),
 	}
 }
 
@@ -75,7 +77,6 @@ func (h *Handler) ensureWatchdog(psmdb *v1alpha1.PerconaServerMongoDB, usersSecr
 	}
 
 	// Start the watchdog if it has not been started
-	metricsCollector := wdMetrics.NewCollector()
 	h.watchdog = watchdog.New(&wdConfig.Config{
 		ServiceName:    psmdb.Name,
 		Username:       string(usersSecret.Data[motPkg.EnvMongoDBClusterAdminUser]),
@@ -83,11 +84,12 @@ func (h *Handler) ensureWatchdog(psmdb *v1alpha1.PerconaServerMongoDB, usersSecr
 		APIPoll:        5 * time.Second,
 		ReplsetPoll:    5 * time.Second,
 		ReplsetTimeout: 3 * time.Second,
-	}, h.pods, metricsCollector, &h.watchdogQuit)
+	}, h.pods, h.watchdogMetrics, &h.watchdogQuit)
 	go h.watchdog.Run()
 
 	// register prometheus collector
-	prometheus.MustRegister(metricsCollector)
+	prometheus.MustRegister(h.watchdogMetrics)
+	log.Debug("Registered watchdog Prometheus collector")
 
 	return nil
 }
@@ -106,8 +108,12 @@ func (h *Handler) Handle(ctx context.Context, event opSdk.Event) error {
 		if event.Deleted {
 			logrus.Infof("received deleted event for %s", psmdb.Name)
 			if h.watchdog != nil {
+				prometheus.Unregister(h.watchdogMetrics)
+				log.Debug("Unregistered watchdog Prometheus collector")
+
 				close(h.watchdogQuit)
 				h.watchdog = nil
+				log.Debuf("Stopped watchdog")
 			}
 			return nil
 		}

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -89,7 +89,7 @@ func (h *Handler) ensureWatchdog(psmdb *v1alpha1.PerconaServerMongoDB, usersSecr
 
 	// register prometheus collector
 	prometheus.MustRegister(h.watchdogMetrics)
-	log.Debug("Registered watchdog Prometheus collector")
+	logrus.Debug("Registered watchdog Prometheus collector")
 
 	return nil
 }
@@ -109,11 +109,11 @@ func (h *Handler) Handle(ctx context.Context, event opSdk.Event) error {
 			logrus.Infof("received deleted event for %s", psmdb.Name)
 			if h.watchdog != nil {
 				prometheus.Unregister(h.watchdogMetrics)
-				log.Debug("Unregistered watchdog Prometheus collector")
+				logrus.Debug("Unregistered watchdog Prometheus collector")
 
 				close(h.watchdogQuit)
 				h.watchdog = nil
-				log.Debuf("Stopped watchdog")
+				logrus.Debug("Stopped watchdog")
 			}
 			return nil
 		}

--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Percona-Lab/percona-server-mongodb-operator/internal/mongod"
 	"github.com/Percona-Lab/percona-server-mongodb-operator/internal/sdk/mocks"
 	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/apis/psmdb/v1alpha1"
+	wdMetrics "github.com/percona/mongodb-orchestration-tools/watchdog/metrics"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	"github.com/stretchr/testify/assert"
@@ -98,7 +99,8 @@ func TestHandlerHandle(t *testing.T) {
 		serverVersion: &v1alpha1.ServerVersion{
 			Platform: v1alpha1.PlatformKubernetes,
 		},
-		watchdogQuit: make(chan bool),
+		watchdogMetrics: wdMetrics.NewCollector(),
+		watchdogQuit:    make(chan bool),
 	}
 
 	// test Handler with no existing stateful sets, test watchdog is started


### PR DESCRIPTION
1. Unregister watchdog prometheus metrics on CR delete to fix panic.

NOTE: this logic will change later when many CRs are fixed/supported.