### PR TITLE
Disable debug logging on operator by default

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -31,4 +31,4 @@ spec:
             - name: RESYNC_PERIOD
               value: 5s
             - name: LOG_VERBOSE
-              value: "true"
+              value: "false"


### PR DESCRIPTION
Debug logging is not meant to be enabled by default (too much logging)