### PR TITLE
Add restore Kubernetes Job, fix restorer script

### DIFF
--- a/backup-restorer.sh
+++ b/backup-restorer.sh
@@ -1,30 +1,33 @@
 #!/bin/bash
 
-set -e
-
-BUCKET=$1
-BACKUP_NAME=$2
-MONGODB_DSN=$3
-
-DUMP_FILE=${BACKUP_NAME}.dump.gz
-OPLOG_FILE=${BACKUP_NAME}.oplog.gz
+[ -z $BUCKET_NAME ] && BUCKET_NAME=$1
+[ -z $BACKUP_NAME ] && BACKUP_NAME=$2
+[ -z $MONGODB_DSN ] && MONGODB_DSN=$3
 
 [ -z $AWS_ACCESS_KEY_ID ] && echo "AWS_ACCESS_KEY_ID environment variable must be set!" && exit 1
 [ -z $AWS_SECRET_ACCESS_KEY ] && echo "AWS_SECRET_ACCESS_KEY environment variable must be set!" && exit 1
 
-if [ -z $BUCKET ] || [ -z $BACKUP_NAME ] || [ -z $MONGODB_DSN ]; then
+if [ -z $BUCKET_NAME ] || [ -z $BACKUP_NAME ] || [ -z $MONGODB_DSN ]; then
   echo "Usage: $0 [S3-BUCKET-NAME] [BACKUP-NAME] [MONGODB_URI]"
   exit 1
 fi
 
-# download database dump file
-echo "# Fetching database backup: s3://${BUCKET}/${DUMP_FILE}"
-aws s3 cp s3://${BUCKET}/${DUMP_FILE} ${DUMP_FILE}
-
-# setup mongorestore gzip flag, if required
-if [[ $DUMP_FILE =~ .gz$ ]]; then
+# check if the backup is gzipped or not
+aws s3 ls s3://${BUCKET_NAME}/${BACKUP_NAME}.dump.gz >/dev/null
+if [ $? = 0 ]; then
+  DUMP_FILE=${BACKUP_NAME}.dump.gz
+  OPLOG_FILE=${BACKUP_NAME}.oplog.gz
   GZIP_FLAG="--gzip"
+else
+  DUMP_FILE=${BACKUP_NAME}.dump
+  OPLOG_FILE=${BACKUP_NAME}.oplog
 fi
+
+set -e
+
+# download database dump file
+echo "# Fetching database backup: s3://${BUCKET_NAME}/${DUMP_FILE}"
+aws s3 cp s3://${BUCKET_NAME}/${DUMP_FILE} ${DUMP_FILE}
 
 # restore dump file
 echo "# Restoring database backup ${DUMP_FILE} to: ${MONGODB_DSN}"
@@ -33,17 +36,17 @@ cat ${DUMP_FILE} | mongorestore $GZIP_FLAG --archive --drop --stopOnError --uri=
 # download and apply the oplog file, if it exists.
 if [ ! -z $OPLOG_FILE ]; then
   set +e
-  aws s3 ls s3://${BUCKET}/${OPLOG_FILE} >/dev/null
+  aws s3 ls s3://${BUCKET_NAME}/${OPLOG_FILE} >/dev/null
   if [ $? -gt 0 ]; then
-    echo "# Found no oplog at s3://${BUCKET}/${OPLOG_FILE}, skipping oplog restore"
+    echo "# Found no oplog at s3://${BUCKET_NAME}/${OPLOG_FILE}, skipping oplog restore"
     exit 1
   fi
   set -e
 
-  echo "# Fetching database oplog s3://${BUCKET}}/${OPLOG_FILE}"
+  echo "# Fetching database oplog s3://${BUCKET_NAME}}/${OPLOG_FILE}"
   OPLOG_DIR=$(mktemp -d)
   cd $OPLOG_DIR
-  aws s3 cp s3://${BUCKET}/${OPLOG_FILE} oplog.bson
+  aws s3 cp s3://${BUCKET_NAME}/${OPLOG_FILE} oplog.bson
 
   echo "# Restoring database oplog ${OPLOG_FILE} to: ${MONGODB_DSN}"
   mongorestore $GZIP_FLAG --dir=. --oplogReplay --stopOnError --uri=$MONGODB_DSN 

--- a/deploy/backup-restore.yaml
+++ b/deploy/backup-restore.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-cluster-name-backup-restorer
+spec:
+  template:
+    spec:
+      containers:
+      - name: backup-restorer
+        image: percona/percona-server-mongodb-operator:backup-pbmctl
+        command: ["/backup-restorer.sh"]
+        env:
+        - name: BACKUP_NAME
+          value: 2019-01-25T13:40:11Z_rs0 
+        - name: BUCKET
+          value: S3-BACKUP-BUCKET-NAME-HERE
+        - name: MONGODB_DSN
+          value: mongodb+srv://BACKUP-USER-HERE:BACKUP-PASSWORD-HERE@my-cluster-name-rs0.psmdb.svc.cluster.local/admin?replicaSet=rs0&ssl=false
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: my-cluster-name-backup-s3
+              key: AWS_ACCESS_KEY_ID
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: my-cluster-name-backup-s3
+              key: AWS_SECRET_ACCESS_KEY
+      restartPolicy: Never
+  backoffLimit: 4

--- a/deploy/backup-restore.yaml
+++ b/deploy/backup-restore.yaml
@@ -12,7 +12,7 @@ spec:
         env:
         - name: BACKUP_NAME
           value: 2019-01-25T13:40:11Z_rs0 
-        - name: BUCKET
+        - name: BUCKET_NAME
           value: S3-BACKUP-BUCKET-NAME-HERE
         - name: MONGODB_DSN
           value: mongodb+srv://BACKUP-USER-HERE:BACKUP-PASSWORD-HERE@my-cluster-name-rs0.psmdb.svc.cluster.local/admin?replicaSet=rs0&ssl=false


### PR DESCRIPTION
1. Check if gzip was enabled properly by doing 'aws s3 ls'.
1. Allow environment variables to set backup name, bucket name and mongodb dsn.
1. Add Kubernetes Job to call the restorer script. This job uses the Kubernetes secret for 

@fiowro, the restore steps will be:
1. Edit deploy/backup-restorer.yaml to have correct:
    1. The name of the Kubernetes secret containing the AWS S3 credentials (should be same as deploy/cr.yaml backup section).
    1. S3 bucket name (should be same as deploy/cr.yaml backup section)
    1. Backup name (this name is unique for each backup - see S3 browser to get the name of available backups)
    1. The mongodb+srv:// connect string with the backup-user username+password (from deploy/mongodb-users.yaml secret file).
1. Run the restore job:
```
oc create -f deploy/backup-restorer.yaml
```