### PR TITLE
Exit 0 if no oplog to restore

### DIFF
--- a/backup-restorer.sh
+++ b/backup-restorer.sh
@@ -39,7 +39,7 @@ if [ ! -z $OPLOG_FILE ]; then
   aws s3 ls s3://${BUCKET_NAME}/${OPLOG_FILE} >/dev/null
   if [ $? -gt 0 ]; then
     echo "# Found no oplog at s3://${BUCKET_NAME}/${OPLOG_FILE}, skipping oplog restore"
-    exit 1
+    exit 0
   fi
   set -e
 


### PR DESCRIPTION
In PBM 0.2.1 it is normal that there is no oplog to restore if there were no changes to the oplog during backup.

In PBM 0.2.2+ restores will work through the agent.