### PR TITLE
Fix arbiter logic

### DIFF
--- a/pkg/stub/psmdb.go
+++ b/pkg/stub/psmdb.go
@@ -91,14 +91,9 @@ func (h *Handler) addSpecDefaults(m *v1alpha1.PerconaServerMongoDB) {
 		}
 	} else {
 		for _, replset := range spec.Replsets {
-			if replset.Size == 0 {
-				replset.Size = config.DefaultMongodSize
-			}
-
 			if !spec.UnsafeConf {
 				setSafeDefault(replset)
 			}
-
 		}
 	}
 	if spec.RunUID == 0 && util.GetPlatform(m, h.serverVersion) != v1alpha1.PlatformOpenshift {
@@ -167,8 +162,6 @@ func (h *Handler) newStatefulSetContainers(m *v1alpha1.PerconaServerMongoDB, rep
 
 // newStatefulSet returns a PSMDB stateful set
 func (h *Handler) newStatefulSet(m *v1alpha1.PerconaServerMongoDB, replset *v1alpha1.ReplsetSpec, resources corev1.ResourceRequirements) (*appsv1.StatefulSet, error) {
-	h.addSpecDefaults(m)
-
 	runUID := util.GetContainerRunUID(m, h.serverVersion)
 	ls := util.LabelsForPerconaServerMongoDBReplset(m, replset)
 	set := util.NewStatefulSet(m, m.Name+"-"+replset.Name)

--- a/pkg/stub/unsafeconf.go
+++ b/pkg/stub/unsafeconf.go
@@ -1,30 +1,33 @@
 package stub
 
 import (
+	"github.com/Percona-Lab/percona-server-mongodb-operator/internal/config"
 	"github.com/Percona-Lab/percona-server-mongodb-operator/pkg/apis/psmdb/v1alpha1"
 	"github.com/sirupsen/logrus"
 )
 
 func setSafeDefault(replset *v1alpha1.ReplsetSpec) {
-	arbiterDefaults(replset)
+	// Replset size can't be 0 or 1.
+	// But 2 + the Arbiter is possible.
+	if replset.Size < 2 {
+		replset.Size = config.DefaultMongodSize
+		logrus.Infof("Replset size will be changed from %d to %d due to safe config", replset.Size, config.DefaultMongodSize)
+		logrus.Infof("Set allowUnsafeConfigurations=true to disable safe configuration")
+	}
 
 	if replset.Arbiter != nil && replset.Arbiter.Enabled {
-
-		if replset.Arbiter.Size > 1 {
-			logrus.Infof("Arbiter size will be decreased from %d to 1 due to safe config", replset.Arbiter.Size)
+		if replset.Arbiter.Size != 1 {
+			logrus.Infof("Arbiter size will be changed from %d to 1 due to safe config", replset.Arbiter.Size)
 			logrus.Infof("Set allowUnsafeConfigurations=true to disable safe configuration")
 			replset.Arbiter.Size = 1
 		}
-
-		if (replset.Size+replset.Arbiter.Size)%2 == 0 {
-			logrus.Infof("Replset size will be increased from %d to %d", replset.Size, replset.Size+1)
+		if replset.Size%2 != 0 {
+			logrus.Infof("Arbiter will be switched off. There is no need in arbiter with odd replset size (%d)", replset.Size)
 			logrus.Infof("Set allowUnsafeConfigurations=true to disable safe configuration")
-
-			replset.Size++
+			replset.Arbiter.Enabled = false
+			replset.Arbiter.Size = 0
 		}
-
 	} else {
-
 		if replset.Size%2 == 0 {
 			logrus.Infof("Replset size will be increased from %d to %d", replset.Size, replset.Size+1)
 			logrus.Infof("Set allowUnsafeConfigurations=true to disable safe configuration")

--- a/pkg/stub/unsafeconf_test.go
+++ b/pkg/stub/unsafeconf_test.go
@@ -14,7 +14,7 @@ func Test_setSafeDefault(t *testing.T) {
 	}
 
 	tests := map[string]args{
-		"pair number": {
+		"even number": {
 			&v1alpha1.ReplsetSpec{
 				Size: 4,
 			},
@@ -22,7 +22,127 @@ func Test_setSafeDefault(t *testing.T) {
 				Size: 5,
 			},
 		},
-		"pair number with arbiter": {
+		"even number2": {
+			&v1alpha1.ReplsetSpec{
+				Size: 2,
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+			},
+		},
+		"0 w/o arbiter ": {
+			&v1alpha1.ReplsetSpec{
+				Size: 0,
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+			},
+		},
+		"0 with arbiter": {
+			&v1alpha1.ReplsetSpec{
+				Size: 0,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    1,
+				},
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: false,
+					Size:    0,
+				},
+			},
+		},
+		"1 w/o arbiter ": {
+			&v1alpha1.ReplsetSpec{
+				Size: 1,
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+			},
+		},
+		"1 with arbiter": {
+			&v1alpha1.ReplsetSpec{
+				Size: 1,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    1,
+				},
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: false,
+					Size:    0,
+				},
+			},
+		},
+		"odd with arbiter": {
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    1,
+				},
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: false,
+					Size:    0,
+				},
+			},
+		},
+		"odd with two arbiters": {
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    2,
+				},
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: false,
+					Size:    0,
+				},
+			},
+		},
+		"odd with three arbiters": {
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    3,
+				},
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 3,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: false,
+					Size:    0,
+				},
+			},
+		},
+		"even with arbiter": {
+			&v1alpha1.ReplsetSpec{
+				Size: 2,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    1,
+				},
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 2,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    1,
+				},
+			},
+		},
+		"even4 with arbiter": {
 			&v1alpha1.ReplsetSpec{
 				Size: 4,
 				Arbiter: &v1alpha1.Arbiter{
@@ -38,13 +158,45 @@ func Test_setSafeDefault(t *testing.T) {
 				},
 			},
 		},
+		"even with two arbiters": {
+			&v1alpha1.ReplsetSpec{
+				Size: 2,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    2,
+				},
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 2,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    1,
+				},
+			},
+		},
+		"even with three arbiters": {
+			&v1alpha1.ReplsetSpec{
+				Size: 2,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    3,
+				},
+			},
+			&v1alpha1.ReplsetSpec{
+				Size: 2,
+				Arbiter: &v1alpha1.Arbiter{
+					Enabled: true,
+					Size:    1,
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			setSafeDefault(test.replset)
 			assert.Equal(t, test.replset.Size, test.expected.Size)
-			if test.replset.Arbiter.Enabled {
+			if test.replset.Arbiter != nil && test.replset.Arbiter.Enabled {
 				assert.Equal(t, test.expected.Arbiter.Size, test.replset.Arbiter.Size)
 			}
 		})


### PR DESCRIPTION
1. There is should be a way to set the 0 replset size in unsafe mode.
2. Now the operator switches off the arbiter instead of adding one more node when the nodes+arbiter size is even. This behavior is better aligned with the requirements in https://jira.percona.com/browse/CLOUD-117.
3. Improved the logic of the arbiter size updating.
4. Cut off redundant checks.