### PR TITLE
Introduction the Delete method for arbiter in the handler broke unit tests

### DIFF
--- a/pkg/stub/handler_test.go
+++ b/pkg/stub/handler_test.go
@@ -143,6 +143,7 @@ func TestHandlerHandle(t *testing.T) {
 			mock.AnythingOfType("*v1.ServiceList"),
 			mock.AnythingOfType("sdk.ListOption"),
 		).Return(nil)
+		client.On("Delete", mock.AnythingOfType("*v1.StatefulSet")).Return(nil)
 
 		assert.NoError(t, h.Handle(context.TODO(), event))
 		assert.Equal(t, map[string]*watchdog.Watchdog{}, h.watchdog)


### PR DESCRIPTION
Test case wasn't expect a Delete method in handler: https://github.com/Percona-Lab/percona-server-mongodb-operator/blob/f2ffc95b03fb81765cfee050f8cf2646e7641997/pkg/stub/replset.go#L226
