### PR TITLE
Use the 0.4.2 tag of mongodb-orchestration-tools

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -259,7 +259,8 @@
     "watchdog/replset",
     "watchdog/watcher"
   ]
-  revision = "398fe3f8568f58b8d353575d08d346bc33c7f130"
+  revision = "7d64c3fef0052e90faaec71d1c4bec531040f893"
+  version = "0.4.2"
 
 [[projects]]
   name = "github.com/percona/percona-backup-mongodb"
@@ -728,6 +729,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "407c1a61cf0223675d0f55c359c297a3ce42d7354c4c9ec263185e710ff9fcb7"
+  inputs-digest = "e27cfe3e377e7903d38fe68b22fd2ca6f0e159e9c5bfb9b345b8590612403826"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,7 +34,7 @@ required = [
 
 [[override]]
   name = "github.com/percona/mongodb-orchestration-tools"
-  revision = "398fe3f8568f58b8d353575d08d346bc33c7f130"
+  version = "0.4.2"
 
 [[override]]
   branch = "master"

--- a/vendor/github.com/percona/mongodb-orchestration-tools/Makefile
+++ b/vendor/github.com/percona/mongodb-orchestration-tools/Makefile
@@ -40,9 +40,11 @@ ifeq ($(TEST_CODECOV), true)
 	TEST_GO_EXTRA=-coverprofile=cover.out -covermode=atomic
 endif
 
-all: bin/mongodb-executor bin/mongodb-healthcheck bin/dcos-mongodb-controller bin/dcos-mongodb-watchdog bin/k8s-mongodb-initiator
+all: dcos k8s
 
-dcos: bin/dcos-mongodb-controller bin/dcos-mongodb-watchdog
+dcos: bin/mongodb-executor bin/mongodb-healthcheck bin/dcos-mongodb-controller bin/dcos-mongodb-watchdog
+
+k8s: bin/k8s-mongodb-initiator bin/mongodb-healthcheck
 
 $(GOPATH)/bin/glide:
 	go get github.com/Masterminds/glide

--- a/vendor/github.com/percona/mongodb-orchestration-tools/cmd/mongodb-executor/main.go
+++ b/vendor/github.com/percona/mongodb-orchestration-tools/cmd/mongodb-executor/main.go
@@ -113,8 +113,8 @@ func main() {
 
 	app.Flag(
 		"service",
-		"DC/OS SDK service/framework name, overridden by env var "+pkg.EnvServiceName,
-	).Default(pkg.DefaultServiceName).Envar(pkg.EnvServiceName).StringVar(&cnf.ServiceName)
+		"DC/OS SDK service/framework name, overridden by env var "+dcos.EnvFrameworkName,
+	).Default(pkg.DefaultServiceName).Envar(dcos.EnvFrameworkName).StringVar(&cnf.ServiceName)
 	app.Flag(
 		"connectRetrySleep",
 		"duration to wait between retries of the connection/ping to mongodb",

--- a/vendor/github.com/percona/mongodb-orchestration-tools/internal/dcos/env.go
+++ b/vendor/github.com/percona/mongodb-orchestration-tools/internal/dcos/env.go
@@ -16,6 +16,7 @@ package dcos
 
 const (
 	EnvFrameworkHost    = "FRAMEWORK_HOST"
+	EnvFrameworkName    = "FRAMEWORK_NAME"
 	EnvPodName          = "POD_NAME"
 	EnvTaskName         = "TASK_NAME"
 	EnvMesosSandbox     = "MESOS_SANDBOX"
@@ -23,7 +24,6 @@ const (
 	EnvSecretsEnabled   = "SECRETS_ENABLED"
 
 	EnvMongoDBMemoryMB                 = "MONGODB_MEM"
-	EnvMongoDBPrimaryAddr              = "MONGODB_PRIMARY_ADDR"
 	EnvMongoDBMongodEndpointName       = "MONGODB_MONGOD_ENDPOINT_NAME"
 	EnvMongoDBChangeUserDb             = "MONGODB_CHANGE_USER_DB"
 	EnvMongoDBChangeUserUsername       = "MONGODB_CHANGE_USER_USERNAME"

--- a/vendor/github.com/percona/mongodb-orchestration-tools/internal/dcos/util.go
+++ b/vendor/github.com/percona/mongodb-orchestration-tools/internal/dcos/util.go
@@ -19,6 +19,14 @@ import (
 	"path/filepath"
 )
 
+// FrameworkHost returns the service/framework host/DNS suffix using
+// the FRAMEWORK_HOST environment variable that is set automatically
+// by DC/OS.
+// Added to resolve https://jira.percona.com/browse/PMDCOS-5
+func FrameworkHost() string {
+	return os.Getenv(EnvFrameworkHost)
+}
+
 func MesosSandboxPathOrFallback(path string, fallback string) string {
 	mesosSandbox := os.Getenv(EnvMesosSandbox)
 	if mesosSandbox != "" {

--- a/vendor/github.com/percona/mongodb-orchestration-tools/pkg/pod/dcos/task.go
+++ b/vendor/github.com/percona/mongodb-orchestration-tools/pkg/pod/dcos/task.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/percona/mongodb-orchestration-tools/internal/dcos"
 	"github.com/percona/mongodb-orchestration-tools/pkg"
 	"github.com/percona/mongodb-orchestration-tools/pkg/db"
 	"github.com/percona/mongodb-orchestration-tools/pkg/pod"
@@ -30,7 +31,6 @@ const backupPodNamePrefix = "backup-"
 type TaskState string
 
 var (
-	AutoIPDNSSuffix   string    = "autoip.dcos.thisdcos.directory"
 	TaskStateError    TaskState = "TASK_ERROR"
 	TaskStateFailed   TaskState = "TASK_FAILED"
 	TaskStateFinished TaskState = "TASK_FINISHED"
@@ -100,7 +100,7 @@ func (task *Task) Name() string {
 }
 
 func (task *Task) Service() string {
-	return os.Getenv(pkg.EnvServiceName)
+	return os.Getenv(dcos.EnvFrameworkName)
 }
 
 func (task *Task) HasState() bool {
@@ -137,11 +137,11 @@ func (task *Task) IsTaskType(taskType pod.TaskType) bool {
 
 func (task *Task) GetMongoAddr() (*db.Addr, error) {
 	addr := &db.Addr{
-		Host: task.data.Info.Name + "." + task.Service() + "." + AutoIPDNSSuffix,
+		Host: task.data.Info.Name + "." + dcos.FrameworkHost(),
 	}
 	portStr, err := task.getEnvVar(pkg.EnvMongoDBPort)
 	if err != nil {
-		return addr, err
+		return nil, err
 	}
 	addr.Port, err = strconv.Atoi(portStr)
 	return addr, err

--- a/vendor/github.com/percona/mongodb-orchestration-tools/watchdog/watcher/watcher.go
+++ b/vendor/github.com/percona/mongodb-orchestration-tools/watchdog/watcher/watcher.go
@@ -98,7 +98,7 @@ func (rw *Watcher) connectReplsetSession() error {
 					session.Close()
 				}
 			} else {
-				return errors.New("no addresses for dial info")
+				log.Errorf("no addresses for mongodb replset: %s", rw.replset.Name)
 			}
 		case <-time.After(connectReplsetTimeout):
 			return errors.New("timeout getting replset connection")


### PR DESCRIPTION
Use the 0.4.2 release (latest) of percona/mongodb-orchestration-tools (instead of a git-revision):

https://github.com/percona/mongodb-orchestration-tools/releases/tag/0.4.2

This includes a fix that should allow replset watchers to retry if they have no members.
